### PR TITLE
fix(gen): drop toxic widen in class-mode constructor signature

### DIFF
--- a/.changeset/codegen-classmode-options-type.md
+++ b/.changeset/codegen-classmode-options-type.md
@@ -1,0 +1,7 @@
+---
+"@quazardous/qdadm": patch
+---
+
+Fix codegen class-mode constructor TS2345 on `fields`. The generated `Generated${X}Manager` constructor was typing its `options` argument as a hand-rolled `Partial<{ ... fields: Record<string, unknown>; [key: string]: unknown }>`. The toxic combo (`Record<string, unknown>` + index signature) widened the inline literal's strictly-typed `fields: Record<string, FieldConfig>` at the `super({ ...literal, ...options })` spread, so `vue-tsc --noEmit` against generated files reported `TS2345: Argument of type '{ ...; fields: Record<string, unknown>; ... }' is not assignable to parameter of type 'EntityManagerOptions<XxxEntity>'`.
+
+The codegen now emits `constructor(options: Partial<EntityManagerOptions<${className}Entity>> = {})` and imports `EntityManagerOptions` from `@quazardous/qdadm`. The signature stays in sync with the parent class automatically — future additions to `EntityManagerOptions` no longer require touching the template — and the strict `fields` typing survives the spread. Reported by skybot-claude on `vue-tsc --noEmit` over generated managers in 1.19.4.

--- a/packages/qdadm/src/gen/generateManagers.test.js
+++ b/packages/qdadm/src/gen/generateManagers.test.js
@@ -427,9 +427,12 @@ describe('generateManagers', () => {
       // Storage must be parameterized in class mode too — same TS2322
       // assignability problem as instance mode if we drop the generic.
       expect(content).toContain('new ApiStorage<UsersEntity>(')
-      // Constructor signature should accept a typed storage override, not `unknown`
-      expect(content).toContain("import type { EntityRecord, IStorage } from '@quazardous/qdadm'")
-      expect(content).toContain('storage: IStorage<UsersEntity>')
+      // Constructor signature delegates to the parent's options type so
+      // `fields: Record<string, FieldConfig>` doesn't widen on spread (TS2345).
+      expect(content).toContain("import type { EntityRecord, EntityManagerOptions } from '@quazardous/qdadm'")
+      expect(content).toContain('options: Partial<EntityManagerOptions<UsersEntity>>')
+      expect(content).not.toContain('Record<string, unknown>')
+      expect(content).not.toContain('[key: string]: unknown')
     })
   })
 

--- a/packages/qdadm/src/gen/generateManagers.ts
+++ b/packages/qdadm/src/gen/generateManagers.ts
@@ -241,7 +241,7 @@ function generateManagerSource(
  */
 
 import { EntityManager } from '@quazardous/qdadm'
-import type { EntityRecord, IStorage } from '@quazardous/qdadm'
+import type { EntityRecord, EntityManagerOptions } from '@quazardous/qdadm'
 import { ${storageClass} } from '${storageImport}'
 
 ${entityInterface}
@@ -252,7 +252,7 @@ ${entityInterface}
  * @extends EntityManager
  */
 export class Generated${className}Manager extends EntityManager<${className}Entity> {
-  constructor(options: Partial<{ name: string; idField: string; fields: Record<string, unknown>; storage: IStorage<${className}Entity>; [key: string]: unknown }> = {}) {
+  constructor(options: Partial<EntityManagerOptions<${className}Entity>> = {}) {
     super({
       ...${serializeValue(managerOptions, 2)},
       storage: new ${storageClass}<${className}Entity>(${serializeValue(fullStorageOptions, 2)}),


### PR DESCRIPTION
## Summary

- Class-mode codegen was typing the generated constructor's `options` as a hand-rolled `Partial<{ ...; fields: Record<string, unknown>; [key: string]: unknown }>`. The index signature widened the inline literal's `fields: Record<string, FieldConfig>` at the `super({ ...lit, ...options })` spread, tripping **TS2345** against `EntityManagerOptions<T>` on consumers running `vue-tsc --noEmit` over their generated managers (reported by `skybot-claude` on aiball#40).
- Switched to `Partial<EntityManagerOptions<${className}Entity>>` — strict `fields` typing survives the spread, and the codegen signature now follows `EntityManagerOptions` automatically if the parent type grows.
- Test (`generateManagers.test.js` class-mode case) updated: now pins `Partial<EntityManagerOptions<UsersEntity>>` and adds negative checks against `Record<string, unknown>` / `[key: string]: unknown` in the output.
- `.changeset/codegen-classmode-options-type.md` — patch bump for `@quazardous/qdadm`.

## Test plan

- [x] `npx vitest run src/gen/generateManagers.test.js` — 31/31 pass on the fix.
- [x] Regenerated a class-mode `bots.ts` fixture and ran `tsc --strict --noEmit` → zero errors. Reverted to the old signature in a side fixture → reproduces the exact TS2345 from the report. Fix is what closes it.
- [ ] CI: typecheck + tests on this branch.
- [ ] After merge: Changesets action opens a "Version Packages" PR bumping `@quazardous/qdadm` → 1.19.5.

Closes the follow-up codegen bug surfaced under aiball#40 (comment `bxsadj`).