### PR TITLE
fix(ci): bump Pages deploy to Node 22

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       - name: Install dependencies


### PR DESCRIPTION
## Summary

- `deploy.yml` was pinned to Node 20 while `release.yml` and local dev run Node 22 — that mismatch was the root cause of every Pages deploy failure since 2026-05-07.
- Vite's config bundler externalizes `@quazardous/qdadm/vite-plugin-debug` (imported in `packages/demo/vite.config.js`) to its resolved `.ts` path. Node 20 strict-refuses the unknown extension with `ERR_UNKNOWN_FILE_EXTENSION`; Node 22 loads it fine.
- Bumping `deploy.yml` to Node 22 aligns the three environments (CI deploy / CI release / local).

## Test plan

- [x] `npm run build -w packages/demo` passes locally on Node 22
- [ ] CI: `Deploy Examples to GitHub Pages` workflow turns green on this PR / on merge to main