### PR TITLE
feat(show): ParentCard — embedded parent cartouche for child lists (B2, #1038)

### DIFF
--- a/.changeset/parent-card-b2.md
+++ b/.changeset/parent-card-b2.md
@@ -1,0 +1,17 @@
+---
+"@quazardous/qdadm": minor
+---
+
+Add `<ParentCard>` — a normalized parent detail cartouche for embedding at the top of a child `ListPage` (the "B2" hybrid composition, qdadm #1038).
+
+On a child-list route, `useListPage` already resolves and exposes the parent record (`parentData` / `parentLoading`) with no extra fetch. `<ParentCard>` renders it read-only above the table, auto-deriving its fields from the parent entity's manager and using the **same** field resolver as `ShowPage`, so the cartouche looks exactly like a real detail page:
+
+```vue
+<template #beforeTable>
+  <ParentCard :entity="'books'" :data="list.parentData.value" :loading="list.parentLoading.value" />
+</template>
+```
+
+Pass `fields` to restrict/order the displayed fields, or use the default slot to render the parent yourself with the resolved field set. Works whether the child route comes from `ctx.crud(...,{foreignKey})` or `ctx.childPage()` — it only depends on `parentData`.
+
+Internally, the show field-resolver (schema-type → display-type mapping, auto reference routes, severity badges) was extracted into a shared `createShowFieldResolver` used by both `useEntityItemShowPage` and `<ParentCard>` — no behavior change to existing show pages.

--- a/.changeset/parent-card-b2.md
+++ b/.changeset/parent-card-b2.md
@@ -1,5 +1,5 @@
 ---
-"@quazardous/qdadm": minor
+"@quazardous/qdadm": patch
 ---
 
 Add `<ParentCard>` — a normalized parent detail cartouche for embedding at the top of a child `ListPage` (the "B2" hybrid composition, qdadm #1038).

--- a/docs/page-compositions.md
+++ b/docs/page-compositions.md
@@ -62,13 +62,14 @@ Pourquoi c'est propre : sur cette route, `useListPage` fait déjà tout le trava
 - le composable **instancie et expose déjà le parent** : `parentData`, `parentId`,
   `parentLoading`, `parentChain`, `parentPage`. **Aucun fetch supplémentaire.**
 
-Il reste juste à *rendre* `parentData`, dans le slot `#beforeTable`, avec les **mêmes
-renderers normalisés que `ShowPage`** (`ShowDisplay` / `ShowField`) — cohérence visuelle
-avec les vraies fiches, pas de markup ad hoc.
+Il reste juste à *rendre* `parentData` dans le slot `#beforeTable`. Le composant
+**`<ParentCard>`** fait ça en une ligne : il dérive automatiquement les champs depuis le
+manager du parent et les rend avec les **mêmes renderers que `ShowPage`** (cohérence
+visuelle avec les vraies fiches, zéro re-fetch).
 
 ```vue
 <script setup>
-import { useListPage, ListPage, ShowField, PageNav } from '@quazardous/qdadm'
+import { useListPage, ListPage, ParentCard, PageNav } from '@quazardous/qdadm'
 import Column from 'primevue/column'
 
 // Route enfant /books/:bookId/loans → parent (book) déjà résolu par useListPage
@@ -83,15 +84,12 @@ list.addEditAction()
 
     <!-- Cartouche parent normalisé, alimenté par parentData (zéro re-fetch) -->
     <template #beforeTable>
-      <div v-if="list.parentLoading.value" class="p-3">
-        <i class="pi pi-spin pi-spinner" />
-      </div>
-      <div v-else-if="list.parentData.value" class="parent-card">
-        <ShowField :field="{ name: 'title', label: 'Book' }"
-          :value="list.parentData.value.title" horizontal />
-        <ShowField :field="{ name: 'author', label: 'Author' }"
-          :value="list.parentData.value.author" horizontal />
-      </div>
+      <ParentCard
+        :entity="'books'"
+        :data="list.parentData.value"
+        :loading="list.parentLoading.value"
+        :fields="['title', 'author']"
+      />
     </template>
 
     <template #columns>
@@ -101,6 +99,9 @@ list.addEditAction()
   </ListPage>
 </template>
 ```
+
+`fields` est optionnel (omis → tous les champs du manager) ; le slot par défaut de
+`<ParentCard>` permet de rendre le parent soi-même à partir du set de champs résolu.
 
 > **Marche via `crud` *ou* `childPage`.** Le cartouche parent ne dépend que de
 > `route.meta.parent` étant posé — donc il fonctionne aussi bien si la route enfant vient de
@@ -113,9 +114,6 @@ list.addEditAction()
 
 - À utiliser quand : la liste enfant se lit « au fil de la fiche » et on veut le contexte
   parent visible en permanence.
-- 🚧 Une brique réutilisable (cartouche parent « plug », façon `usePage`) est suivie dans
-  **#1038** ; en attendant, la recette ci-dessus (slot + `ShowField` sur `parentData`) est
-  le pattern de référence.
 
 ### B1 — Show parent hôte + liste enfant inline · *échappatoire*
 

--- a/packages/qdadm/src/components/index.ts
+++ b/packages/qdadm/src/components/index.ts
@@ -36,6 +36,7 @@ export { default as LookupPickerDialog } from './edit/LookupPickerDialog.vue'
 export { default as ShowPage } from './show/ShowPage.vue'
 export { default as ShowField } from './show/ShowField.vue'
 export { default as ShowDisplay } from './show/ShowDisplay.vue'
+export { default as ParentCard } from './show/ParentCard.vue'
 
 // Lists
 export { default as ListPage } from './lists/ListPage.vue'

--- a/packages/qdadm/src/components/show/ParentCard.vue
+++ b/packages/qdadm/src/components/show/ParentCard.vue
@@ -1,0 +1,112 @@
+<script setup lang="ts">
+/**
+ * ParentCard - normalized parent detail embedded at the top of a child ListPage
+ *
+ * The "B2" hybrid composition (see docs/page-compositions.md): a child list is
+ * the host page, and the parent record is shown as a read-only cartouche above
+ * the table. `useListPage` already resolves and exposes the parent on a child
+ * route (`parentData` / `parentLoading`) — this component just renders it, with
+ * the SAME field resolver as `ShowPage` so the look matches real detail pages.
+ * No extra fetch.
+ *
+ * Fields are auto-derived from the parent entity's manager. Pass `fields` to
+ * restrict/order them, or use the default slot to render the parent yourself.
+ *
+ * Usage (inside a child ListPage):
+ *   <template #beforeTable>
+ *     <ParentCard
+ *       :entity="'books'"
+ *       :data="list.parentData.value"
+ *       :loading="list.parentLoading.value"
+ *       :fields="['title', 'author']"
+ *     />
+ *   </template>
+ */
+import { computed, type PropType } from 'vue'
+import { useOrchestrator } from '../../orchestrator/useOrchestrator'
+import { useFieldManager } from '../../composables/useFieldManager'
+import {
+  createShowFieldResolver,
+  type ShowResolvedFieldConfig,
+} from '../../composables/createShowFieldResolver'
+import ShowField from './ShowField.vue'
+
+const props = defineProps({
+  /** Parent entity name (route-stable). */
+  entity: { type: String, required: true },
+  /** Parent record (e.g. `list.parentData.value`). */
+  data: { type: Object as PropType<Record<string, unknown> | null>, default: null },
+  /** Parent loading state (e.g. `list.parentLoading.value`). */
+  loading: { type: Boolean, default: false },
+  /** Restrict/order the displayed fields. Omit to show all manager fields. */
+  fields: { type: Array as PropType<string[] | null>, default: null },
+  /** Exclude these fields (applied when `fields` is not set). */
+  exclude: { type: Array as PropType<string[]>, default: () => [] },
+  /** Render fields horizontally (label beside value). Default true. */
+  horizontal: { type: Boolean, default: true },
+  /** Optional heading above the fields. */
+  title: { type: String, default: '' },
+})
+
+const { orchestrator, getManager } = useOrchestrator()
+const manager = getManager(props.entity)
+
+// Same resolver as ShowPage → identical rendering (types, references, severity).
+const fieldManager = useFieldManager<ShowResolvedFieldConfig>({
+  resolveFieldConfig: createShowFieldResolver(manager, orchestrator),
+  getSchemaFieldConfig: (name) => manager.getFieldConfig?.(name) || null,
+  entity: props.entity,
+})
+
+fieldManager.generateFields(manager.getFormFields?.() || [], {
+  only: props.fields ?? null,
+  exclude: props.fields ? [] : props.exclude,
+})
+// Honor the caller's field order when an explicit list is given.
+if (props.fields) fieldManager.setFieldOrder(props.fields)
+
+const resolvedFields = fieldManager.fields
+const hasData = computed(() => props.data !== null && props.data !== undefined)
+</script>
+
+<template>
+  <div class="parent-card">
+    <div v-if="loading" class="parent-card__loading">
+      <i class="pi pi-spin pi-spinner" />
+    </div>
+
+    <template v-else-if="hasData">
+      <div v-if="title" class="parent-card__title">{{ title }}</div>
+      <!-- Escape hatch: render the parent yourself with the resolved fields. -->
+      <slot :fields="resolvedFields" :data="data">
+        <div class="parent-card__fields">
+          <ShowField
+            v-for="f in resolvedFields"
+            :key="f.name"
+            :field="f"
+            :value="(data?.[f.name] ?? null) as any"
+            :horizontal="horizontal"
+          />
+        </div>
+      </slot>
+    </template>
+  </div>
+</template>
+
+<style scoped>
+.parent-card {
+  margin-bottom: 1rem;
+}
+.parent-card__loading {
+  padding: 0.5rem 0;
+}
+.parent-card__title {
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+}
+.parent-card__fields {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+</style>

--- a/packages/qdadm/src/composables/createShowFieldResolver.ts
+++ b/packages/qdadm/src/composables/createShowFieldResolver.ts
@@ -1,0 +1,170 @@
+/**
+ * createShowFieldResolver - shared read-only field resolver
+ *
+ * Factory producing the field resolver used by read-only display surfaces
+ * (`useEntityItemShowPage`, `<ParentCard>`). Given an entity manager and the
+ * orchestrator, it maps a raw schema field config to a resolved display config:
+ *
+ * - schema type → display type (via {@link SHOW_TYPE_MAPPINGS})
+ * - auto reference route when a field points at another entity
+ * - auto severity (badge) from the manager's severity maps
+ *
+ * Extracted so the parent cartouche of an embedded child list (#1038) renders
+ * fields exactly like a real `ShowPage` — same resolver, same look — without
+ * duplicating the mapping logic.
+ */
+import { snakeCaseToTitle } from './useFieldManager'
+
+/** Severity descriptor returned by a manager's severity maps. */
+type SeverityDescriptor = string | { severity: string; icon?: string; label?: string }
+
+/**
+ * Minimal manager surface the resolver needs — kept structural (not the full
+ * generic `EntityManager`) so it accepts any concrete manager without variance
+ * friction.
+ */
+export interface ShowResolverManager {
+  routePrefix?: string
+  idField: string
+  hasSeverityMap?: (name: string) => boolean
+  getSeverityDescriptor?: (name: string, value: string | number, fallback: string) => SeverityDescriptor
+  getSeverity?: (name: string, value: string | number, fallback: string) => SeverityDescriptor
+}
+
+/**
+ * Field definition from an EntityManager schema.
+ */
+export interface ShowFieldDefinition {
+  name: string
+  type?: string
+  schemaType?: string
+  label?: string
+  reference?: string
+  referenceRoute?: string | ((value: unknown) => { name: string; params: Record<string, unknown> })
+  referenceLabel?: string | ((value: unknown, option?: unknown) => string)
+  options?: unknown[]
+  optionLabel?: string
+  optionValue?: string
+  // Display options
+  dateFormat?: string
+  currencyCode?: string
+  locale?: string
+  booleanLabels?: { true: string; false: string }
+  severity?: string | ((value: unknown) => string | { severity: string; icon?: string; label?: string })
+  imageWidth?: string
+  imageHeight?: string
+  render?: (value: unknown) => string
+  [key: string]: unknown
+}
+
+/**
+ * Resolved field configuration for display rendering.
+ */
+export interface ShowResolvedFieldConfig extends ShowFieldDefinition {
+  name: string
+  type: string
+  schemaType: string
+  label: string
+  group?: string
+}
+
+/**
+ * Minimal orchestrator surface the resolver needs (reference-route lookup).
+ */
+export interface ShowResolverOrchestrator {
+  get: (entityName: string) => ShowResolverManager | undefined
+}
+
+/**
+ * Schema type → display type mapping.
+ */
+export const SHOW_TYPE_MAPPINGS: Record<string, string> = {
+  text: 'text',
+  string: 'text',
+  email: 'email',
+  password: 'password',
+  number: 'number',
+  integer: 'number',
+  float: 'number',
+  decimal: 'number',
+  currency: 'currency',
+  boolean: 'boolean',
+  bool: 'boolean',
+  date: 'date',
+  datetime: 'datetime',
+  time: 'datetime',
+  timestamp: 'datetime',
+  select: 'select',
+  enum: 'select',
+  textarea: 'textarea',
+  longtext: 'textarea',
+  reference: 'reference',
+  foreignKey: 'reference',
+  image: 'image',
+  url: 'url',
+  link: 'url',
+  json: 'json',
+  object: 'json',
+  array: 'json',
+  badge: 'badge',
+  tag: 'badge',
+}
+
+/**
+ * Build a show-style field resolver bound to a manager + orchestrator.
+ */
+export function createShowFieldResolver(
+  manager: ShowResolverManager,
+  orchestrator: ShowResolverOrchestrator
+): (name: string, fieldConfig: Partial<ShowFieldDefinition>) => ShowResolvedFieldConfig {
+  return function resolveFieldConfig(
+    name: string,
+    fieldConfig: Partial<ShowFieldDefinition>
+  ): ShowResolvedFieldConfig {
+    const {
+      type = 'text',
+      schemaType = type,
+      label = '',
+      reference = '',
+      severity,
+      ...rest
+    } = fieldConfig
+
+    let resolvedDisplayType = SHOW_TYPE_MAPPINGS[type] || SHOW_TYPE_MAPPINGS[schemaType] || 'text'
+    const resolvedLabel = label || snakeCaseToTitle(name)
+
+    // Auto-set reference route if reference entity is specified
+    let referenceRoute = rest.referenceRoute
+    if (reference && !referenceRoute) {
+      const refManager = orchestrator.get(reference)
+      if (refManager) {
+        referenceRoute = (value: unknown) => ({
+          name: `${refManager.routePrefix || reference}-show`,
+          params: { [refManager.idField]: value },
+        })
+      }
+    }
+
+    // Auto-inject severity from manager's severity maps
+    let resolvedSeverity = severity
+    if (!resolvedSeverity && manager.hasSeverityMap?.(name)) {
+      resolvedSeverity = manager.getSeverityDescriptor
+        ? (value: unknown) => manager.getSeverityDescriptor!(name, value as string | number, 'secondary')
+        : (value: unknown) => manager.getSeverity!(name, value as string | number, 'secondary')
+      if (resolvedDisplayType === 'text') {
+        resolvedDisplayType = 'badge'
+      }
+    }
+
+    return {
+      name,
+      type: resolvedDisplayType,
+      schemaType,
+      label: resolvedLabel,
+      reference,
+      referenceRoute,
+      severity: resolvedSeverity,
+      ...rest,
+    }
+  }
+}

--- a/packages/qdadm/src/composables/useEntityItemShowPage.ts
+++ b/packages/qdadm/src/composables/useEntityItemShowPage.ts
@@ -33,24 +33,27 @@
  * <ShowPage v-bind="show.props.value" v-on="show.events" />
  * ```
  */
-import { ref, computed, watch, type Ref, type ComputedRef } from 'vue'
-import { useRouter, useRoute, type Router } from 'vue-router'
+import { ref, computed, type Ref, type ComputedRef } from 'vue'
+import { useRouter, type Router } from 'vue-router'
 import { useConfirm } from 'primevue/useconfirm'
 import {
   useEntityItemPage,
   type ParentConfig,
   type EntityManager,
-  type UseEntityItemPageReturn,
 } from './useEntityItemPage'
 import type { StackHydratorReturn } from '../chain/useStackHydrator'
 import {
   useFieldManager,
-  snakeCaseToTitle,
   type FieldGroup,
   type GroupDefinition,
   type GroupOptions,
   type AddFieldOptions,
 } from './useFieldManager'
+import {
+  createShowFieldResolver,
+  type ShowFieldDefinition,
+  type ShowResolvedFieldConfig,
+} from './createShowFieldResolver'
 
 /**
  * Orchestrator interface
@@ -66,41 +69,16 @@ interface Orchestrator {
 }
 
 /**
- * Field definition from EntityManager schema
+ * Field definition from EntityManager schema.
+ * Re-exported from the shared resolver under the historical name.
  */
-export interface FieldDefinition {
-  name: string
-  type?: string
-  schemaType?: string
-  label?: string
-  reference?: string
-  referenceRoute?: string | ((value: unknown) => { name: string; params: Record<string, unknown> })
-  referenceLabel?: string | ((value: unknown, option?: unknown) => string)
-  options?: unknown[]
-  optionLabel?: string
-  optionValue?: string
-  // Display options
-  dateFormat?: string
-  currencyCode?: string
-  locale?: string
-  booleanLabels?: { true: string; false: string }
-  severity?: string | ((value: unknown) => string | { severity: string; icon?: string; label?: string })
-  imageWidth?: string
-  imageHeight?: string
-  render?: (value: unknown) => string
-  [key: string]: unknown
-}
+export type FieldDefinition = ShowFieldDefinition
 
 /**
- * Resolved field configuration for display rendering
+ * Resolved field configuration for display rendering.
+ * Re-exported from the shared resolver under the historical name.
  */
-export interface ResolvedFieldConfig extends FieldDefinition {
-  name: string
-  type: string
-  schemaType: string
-  label: string
-  group?: string
-}
+export type ResolvedFieldConfig = ShowResolvedFieldConfig
 
 // FieldGroup, GroupDefinition, GroupOptions imported from useFieldManager
 
@@ -175,43 +153,6 @@ export interface ShowPageEvents {
   delete: () => void
   back: () => void
 }
-
-/**
- * Type mapping from schema types to display types
- */
-const TYPE_MAPPINGS: Record<string, string> = {
-  text: 'text',
-  string: 'text',
-  email: 'email',
-  password: 'password',
-  number: 'number',
-  integer: 'number',
-  float: 'number',
-  decimal: 'number',
-  currency: 'currency',
-  boolean: 'boolean',
-  bool: 'boolean',
-  date: 'date',
-  datetime: 'datetime',
-  time: 'datetime',
-  timestamp: 'datetime',
-  select: 'select',
-  enum: 'select',
-  textarea: 'textarea',
-  longtext: 'textarea',
-  reference: 'reference',
-  foreignKey: 'reference',
-  image: 'image',
-  url: 'url',
-  link: 'url',
-  json: 'json',
-  object: 'json',
-  array: 'json',
-  badge: 'badge',
-  tag: 'badge',
-}
-
-// snakeCaseToTitle imported from useFieldManager
 
 /**
  * Options for useEntityItemShowPage
@@ -327,7 +268,6 @@ export function useEntityItemShowPage<T = unknown>(
   const { entity, loadOnMount = true, transformLoad, onLoadSuccess, onLoadError } = options
 
   const router: Router = useRouter()
-  const route = useRoute()
   const confirm = useConfirm() as ConfirmService
 
   // Lazy action state (declared before base so onLoadSuccess wrapper can reference it)
@@ -376,56 +316,8 @@ export function useEntityItemShowPage<T = unknown>(
 
   // ============ FIELD & GROUP MANAGEMENT (via useFieldManager) ============
 
-  /**
-   * Show-specific field resolver with reference route auto-detection
-   */
-  function resolveFieldConfig(name: string, fieldConfig: Partial<FieldDefinition>): ResolvedFieldConfig {
-    const {
-      type = 'text',
-      schemaType = type,
-      label = '',
-      reference = '',
-      severity,
-      ...rest
-    } = fieldConfig
-
-    let resolvedDisplayType = TYPE_MAPPINGS[type] || TYPE_MAPPINGS[schemaType] || 'text'
-    const resolvedLabel = label || snakeCaseToTitle(name)
-
-    // Auto-set reference route if reference entity is specified
-    let referenceRoute = rest.referenceRoute
-    if (reference && !referenceRoute) {
-      const refManager = orchestrator.get(reference)
-      if (refManager) {
-        referenceRoute = (value: unknown) => ({
-          name: `${refManager.routePrefix || reference}-show`,
-          params: { [refManager.idField]: value },
-        })
-      }
-    }
-
-    // Auto-inject severity from manager's severity maps
-    let resolvedSeverity = severity
-    if (!resolvedSeverity && manager.hasSeverityMap?.(name)) {
-      resolvedSeverity = manager.getSeverityDescriptor
-        ? (value: unknown) => manager.getSeverityDescriptor!(name, value as string | number, 'secondary')
-        : (value: unknown) => manager.getSeverity!(name, value as string | number, 'secondary')
-      if (resolvedDisplayType === 'text') {
-        resolvedDisplayType = 'badge'
-      }
-    }
-
-    return {
-      name,
-      type: resolvedDisplayType,
-      schemaType,
-      label: resolvedLabel,
-      reference,
-      referenceRoute,
-      severity: resolvedSeverity,
-      ...rest,
-    }
-  }
+  // Show-specific field resolver (shared with <ParentCard>, see #1038)
+  const resolveFieldConfig = createShowFieldResolver(manager, orchestrator)
 
   // Create field manager with show-specific resolver
   const fieldManager = useFieldManager<ResolvedFieldConfig>({

--- a/packages/qdadm/tests/components/ParentCard.test.js
+++ b/packages/qdadm/tests/components/ParentCard.test.js
@@ -1,0 +1,99 @@
+/**
+ * Unit tests for ParentCard — the B2 hybrid parent cartouche (#1038).
+ *
+ * Run: npm test
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import ParentCard from '../../src/components/show/ParentCard.vue'
+
+// Stub ShowField so we assert what ParentCard derives/passes, not ShowDisplay internals.
+vi.mock('../../src/components/show/ShowField.vue', () => ({
+  default: {
+    name: 'ShowField',
+    props: ['field', 'value', 'horizontal'],
+    template:
+      '<div class="show-field" :data-field="field?.name" :data-type="field?.type" :data-horizontal="String(horizontal)">{{ value }}</div>',
+  },
+}))
+
+function makeManager() {
+  return {
+    idField: 'id',
+    routePrefix: 'books',
+    hasSeverityMap: () => false,
+    getFormFields: () => [
+      { name: 'title', type: 'text', label: 'Title' },
+      { name: 'author', type: 'text', label: 'Author' },
+      { name: 'year', type: 'number' },
+    ],
+    getFieldConfig: (name) =>
+      ({
+        title: { type: 'text', label: 'Title' },
+        author: { type: 'text', label: 'Author' },
+        year: { type: 'number' },
+      })[name] || null,
+  }
+}
+
+function mountCard(props, manager = makeManager()) {
+  const orchestrator = { get: () => manager }
+  return mount(ParentCard, {
+    props,
+    global: {
+      provide: { qdadmOrchestrator: orchestrator },
+    },
+  })
+}
+
+describe('ParentCard', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('auto-derives all manager fields and maps values from data', () => {
+    const wrapper = mountCard({
+      entity: 'books',
+      data: { title: 'Dune', author: 'Herbert', year: 1965 },
+    })
+    const fields = wrapper.findAll('.show-field')
+    expect(fields).toHaveLength(3)
+    expect(fields.map((f) => f.attributes('data-field'))).toEqual(['title', 'author', 'year'])
+    expect(fields[0].text()).toBe('Dune')
+    expect(fields[2].text()).toBe('1965')
+    // number type resolves through the show type mapping
+    expect(fields[2].attributes('data-type')).toBe('number')
+  })
+
+  it('restricts and orders fields via the `fields` prop', () => {
+    const wrapper = mountCard({
+      entity: 'books',
+      data: { title: 'Dune', author: 'Herbert', year: 1965 },
+      fields: ['author', 'title'],
+    })
+    const fields = wrapper.findAll('.show-field')
+    expect(fields.map((f) => f.attributes('data-field'))).toEqual(['author', 'title'])
+  })
+
+  it('shows a spinner and no fields while loading', () => {
+    const wrapper = mountCard({ entity: 'books', data: null, loading: true })
+    expect(wrapper.find('.parent-card__loading').exists()).toBe(true)
+    expect(wrapper.findAll('.show-field')).toHaveLength(0)
+  })
+
+  it('renders nothing when there is no data and not loading', () => {
+    const wrapper = mountCard({ entity: 'books', data: null })
+    expect(wrapper.find('.parent-card__loading').exists()).toBe(false)
+    expect(wrapper.findAll('.show-field')).toHaveLength(0)
+  })
+
+  it('passes horizontal through and renders an optional title', () => {
+    const wrapper = mountCard({
+      entity: 'books',
+      data: { title: 'Dune' },
+      fields: ['title'],
+      horizontal: false,
+      title: 'Book',
+    })
+    expect(wrapper.find('.parent-card__title').text()).toBe('Book')
+    expect(wrapper.find('.show-field').attributes('data-horizontal')).toBe('false')
+  })
+})


### PR DESCRIPTION
Implements **#1038** — makes the B2 hybrid composition (child `ListPage` host + normalized parent detail embedded) first-class.

## What
`<ParentCard>` renders a read-only parent cartouche at the top of a child list, fed by the `parentData` that `useListPage` already resolves on a child route — **zero extra fetch**. It auto-derives the parent's fields from its entity manager and reuses **the same field resolver as `ShowPage`**, so the cartouche looks identical to a real detail page.

```vue
<template #beforeTable>
  <ParentCard :entity="'books'" :data="list.parentData.value" :loading="list.parentLoading.value" />
</template>
```

- Props: `entity` (required), `data`, `loading`, `fields?` (restrict/order), `exclude?`, `horizontal?`, `title?`.
- Default slot exposes the resolved field set as an escape hatch.
- Works whether the child route comes from `ctx.crud(...,{foreignKey})` or `ctx.childPage()` — it only depends on `parentData` (the nuance skybot validated on #1037).

## How
- Extracted the show field-resolver (schema-type → display-type mapping, auto reference routes, severity badges) into a shared `createShowFieldResolver`, now used by both `useEntityItemShowPage` and `<ParentCard>`. **No behavior change** to existing show pages.
- New `ParentCard.vue`, exported from the components index (and surfaced from the package root + `./components`).
- Updated `docs/page-compositions.md` B2 section to use the component.
- Dropped a few pre-existing unused imports in `useEntityItemShowPage.ts`.

## Validation
- `vue-tsc --noEmit`: clean.
- eslint on changed files: clean (one pre-existing `any` warning, untouched).
- Tests: **66 files / 1944 passing** (incl. 5 new `ParentCard` tests covering auto-derivation, `fields` restrict/order, loading, empty, horizontal/title).

Minor (`minor` changeset included). Closes #1038.