### PR TITLE
feat(i18n): emitMissing option to silence i18n:missing signal (#1048)

### DIFF
--- a/.changeset/i18n-emit-missing-flag.md
+++ b/.changeset/i18n-emit-missing-flag.md
@@ -1,0 +1,7 @@
+---
+"@quazardous/qdadm": minor
+---
+
+Add `i18n.emitMissing` option (default `true`) to silence the `i18n:missing` debug signal (qdadm #1048).
+
+In an untranslated app, every unresolved key fires `i18n:missing`, flooding the debug panel's "Missing" section. Set `new Kernel({ i18n: { emitMissing: false } })` to suppress that stream. No functional impact — only the debug collector consumes the signal, so the section just stays empty; `i18n:domain-loaded`, `locale:changed`, and the inbound `locale:change` listener are unaffected.

--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -280,6 +280,14 @@ new Kernel({ i18n: { disableDefaultCoreBundle: true } })
   signals.on('i18n:missing', ({ data }) => console.warn('[i18n missing]', data))
   ```
 
+  In an untranslated app this fires on essentially every key and floods the debug panel's "Missing" section. Silence it with `emitMissing: false`:
+
+  ```js
+  new Kernel({ i18n: { emitMissing: false } })
+  ```
+
+  No functional impact — only the debug collector consumes this signal, so the "Missing" section just stays empty.
+
 - **`kernel.i18n.resolve(key)`** returns the full resolution trace (lookup steps, alias chain, hit/miss). Useful when a label resolves to something unexpected.
 
 - **`kernel.i18n.dump(locale)`** exports the merged inline bundle, suitable for handing to a translator.

--- a/packages/qdadm/src/i18n/I18n.ts
+++ b/packages/qdadm/src/i18n/I18n.ts
@@ -59,6 +59,7 @@ export class I18n {
   private _appAliases: AliasPattern[]
   private _entityToModule: Map<string, string> = new Map()
   private _signals: I18nDeps['signals']
+  private _emitMissing: boolean
   private _defaultLocale: string
   private _fallbackLocale: string
   private _loadedLocales: Set<string> = new Set()
@@ -76,6 +77,7 @@ export class I18n {
     this._strategyName = options.keyStrategy ?? 'global'
     this._appAliases = options.aliases ? [...options.aliases] : []
     this._signals = deps.signals ?? null
+    this._emitMissing = options.emitMissing ?? true
 
     this._registry = new MessagesRegistry()
     this.inline = new InlineTranslationProvider()
@@ -99,7 +101,7 @@ export class I18n {
       fallbackLocale: this._fallbackLocale,
       globalAliases: this._currentStrategyAliases(),
       onMissing: (key, locale) => {
-        this._signals?.emit('i18n:missing', { key, locale })
+        if (this._emitMissing) this._signals?.emit('i18n:missing', { key, locale })
       },
     })
 

--- a/packages/qdadm/src/i18n/__tests__/I18n.test.ts
+++ b/packages/qdadm/src/i18n/__tests__/I18n.test.ts
@@ -105,6 +105,37 @@ describe('I18n — locale change', () => {
   })
 })
 
+describe('I18n — emitMissing flag', () => {
+  function makeSignals() {
+    const events: Array<{ signal: string; data: unknown }> = []
+    return {
+      events,
+      signals: {
+        emit: (signal: string, data: unknown) => {
+          events.push({ signal, data })
+        },
+        on: () => () => {},
+      },
+    }
+  }
+
+  it('emits i18n:missing on an unresolved key by default', async () => {
+    const { events, signals } = makeSignals()
+    const i18n = new I18n({ disableDefaultCoreBundle: true }, { signals })
+    await i18n.bootstrap()
+    i18n.t('totally.unknown.key')
+    expect(events.some((e) => e.signal === 'i18n:missing')).toBe(true)
+  })
+
+  it('does not emit i18n:missing when emitMissing is false', async () => {
+    const { events, signals } = makeSignals()
+    const i18n = new I18n({ disableDefaultCoreBundle: true, emitMissing: false }, { signals })
+    await i18n.bootstrap()
+    i18n.t('totally.unknown.key')
+    expect(events.some((e) => e.signal === 'i18n:missing')).toBe(false)
+  })
+})
+
 describe('I18n — providers', () => {
   it('loads from a custom TranslationProvider during bootstrap', async () => {
     const provider: TranslationProvider = {

--- a/packages/qdadm/src/i18n/types.ts
+++ b/packages/qdadm/src/i18n/types.ts
@@ -31,4 +31,12 @@ export type {
 export interface I18nOptions extends BaseI18nOptions {
   /** Disable shipping qdadm's default core.* bundles (EN + FR). Default: false. */
   disableDefaultCoreBundle?: boolean
+  /**
+   * Emit the `i18n:missing` debug signal when a key cannot be resolved.
+   * Default: `true`. Set to `false` to silence the missing-key stream (e.g. an
+   * untranslated app where every key would otherwise fire it) — the debug
+   * panel's "Missing" section then stays empty. No functional impact: nothing
+   * but the debug collector consumes this signal.
+   */
+  emitMissing?: boolean
 }


### PR DESCRIPTION
Implements **#1048**.

## What
New `I18nOptions.emitMissing` (default `true`). Set `false` to stop `I18n` emitting the `i18n:missing` debug signal:

```js
new Kernel({ i18n: { emitMissing: false } })
```

## Why
`i18n:missing` fires on every unresolved key — in an untranslated app that's constant noise flooding the debug panel's "Missing" section. Nothing but the debug collector consumes this signal, so suppressing it has **zero functional impact**; the section just stays empty. `i18n:domain-loaded`, `locale:changed`, and the inbound `locale:change` listener are untouched.

## Changes
- `I18nOptions.emitMissing` (`i18n/types.ts`).
- Gate the single `onMissing` emit in `I18n.ts`.
- 2 tests (emits by default / silent when `false`).
- `docs/i18n.md` dev-tools note.
- `minor` changeset.

## Validation
- `vue-tsc --noEmit`: clean. eslint on changed files: clean.
- i18n suite: 51 passing (incl. 2 new).

Closes #1048.