### PR TITLE
feat(editors): VanillaJsonEditor inline JSON Schema validation (#1050)

### DIFF
--- a/.changeset/jsoneditor-schema-validator.md
+++ b/.changeset/jsoneditor-schema-validator.md
@@ -1,0 +1,13 @@
+---
+"@quazardous/qdadm": minor
+---
+
+`VanillaJsonEditor` now supports inline JSON Schema validation (qdadm #1050).
+
+New optional props forward vanilla-jsoneditor's native `validator`:
+
+- `:schema="<JSON Schema>"` — compiled with `createAjvValidator` (Ajv is bundled in vanilla-jsoneditor, no new dependency), errors are highlighted live in the editor tree/text;
+- `:validator="<fn>"` — a raw validator for advanced cases, takes precedence over `schema`;
+- `:schema-definitions` / `:ajv-options` — passthrough to the Ajv validator.
+
+With none set, behavior is unchanged (no validation). Schema/validator changes are reactive (`editor.updateProps`). Validation errors already surface through the existing `error` event and the editor's status bar.

--- a/packages/qdadm/src/components/editors/VanillaJsonEditor.vue
+++ b/packages/qdadm/src/components/editors/VanillaJsonEditor.vue
@@ -6,10 +6,17 @@
  *
  * Usage:
  * <VanillaJsonEditor v-model="jsonData" mode="tree" />
+ *
+ * Inline JSON Schema validation (errors highlighted live in the editor):
+ * <VanillaJsonEditor v-model="jsonData" :schema="mySchema" />
+ *
+ * Or a raw validator for advanced cases (takes precedence over `schema`):
+ * <VanillaJsonEditor v-model="jsonData" :validator="myValidator" />
  */
 
 import { ref, watch, onMounted, onUnmounted, nextTick } from 'vue'
 import { JSONEditor, type Content, type ContentErrors, type OnChangeStatus, type Mode } from 'vanilla-jsoneditor'
+import { buildJsonValidator, type Validator, type JSONSchema, type JsonValidatorOptions } from './jsonValidator'
 
 type JsonValue = Record<string, unknown> | unknown[] | string | null
 
@@ -21,6 +28,14 @@ interface Props {
   mainMenuBar?: boolean
   navigationBar?: boolean
   statusBar?: boolean
+  /** JSON Schema for inline Ajv validation (errors highlighted in the editor). */
+  schema?: JSONSchema
+  /** Raw validator function — takes precedence over `schema`. */
+  validator?: Validator
+  /** Optional `$ref` definitions passed through to the Ajv validator. */
+  schemaDefinitions?: JsonValidatorOptions['schemaDefinitions']
+  /** Optional Ajv options passed through to the Ajv validator. */
+  ajvOptions?: JsonValidatorOptions['ajvOptions']
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -30,8 +45,22 @@ const props = withDefaults(defineProps<Props>(), {
   readOnly: false,
   mainMenuBar: true,
   navigationBar: true,
-  statusBar: true
+  statusBar: true,
+  schema: undefined,
+  validator: undefined,
+  schemaDefinitions: undefined,
+  ajvOptions: undefined
 })
+
+// Resolve the effective validator from props (raw validator > schema > none).
+function resolveValidator(): Validator | undefined {
+  return buildJsonValidator({
+    validator: props.validator,
+    schema: props.schema,
+    schemaDefinitions: props.schemaDefinitions,
+    ajvOptions: props.ajvOptions
+  })
+}
 
 const emit = defineEmits<{
   'update:modelValue': [value: JsonValue]
@@ -76,6 +105,7 @@ onMounted(() => {
       mainMenuBar: props.mainMenuBar,
       navigationBar: props.navigationBar,
       statusBar: props.statusBar,
+      validator: resolveValidator(),
       onChange: (updatedContent: Content, _previousContent: Content, { contentErrors }: OnChangeStatus) => {
         // Skip if this change came from a programmatic prop update
         if (updatingFromProp.value) return
@@ -143,6 +173,17 @@ watch(() => props.readOnly, (newReadOnly: boolean) => {
     editor.updateProps({ readOnly: newReadOnly })
   }
 })
+
+// Watch validator/schema changes — rebuild and re-apply so edits re-validate live
+watch(
+  () => [props.validator, props.schema, props.schemaDefinitions, props.ajvOptions],
+  () => {
+    if (editor) {
+      editor.updateProps({ validator: resolveValidator() })
+    }
+  },
+  { deep: true }
+)
 
 // Cleanup
 onUnmounted(() => {

--- a/packages/qdadm/src/components/editors/jsonValidator.ts
+++ b/packages/qdadm/src/components/editors/jsonValidator.ts
@@ -1,0 +1,44 @@
+/**
+ * jsonValidator - build a vanilla-jsoneditor `Validator` from wrapper props.
+ *
+ * Pure helper extracted from VanillaJsonEditor so the resolution logic
+ * (raw validator vs JSON Schema vs none) is unit-testable without mounting the
+ * Svelte editor. See qdadm #1050.
+ */
+import {
+  createAjvValidator,
+  type Validator,
+  type JSONSchema,
+  type AjvValidatorOptions,
+} from 'vanilla-jsoneditor'
+
+export type { Validator, JSONSchema }
+
+export interface JsonValidatorOptions {
+  /** Raw validator function — takes precedence over `schema` when both are set. */
+  validator?: Validator
+  /** JSON Schema; compiled to a validator via Ajv (bundled in vanilla-jsoneditor). */
+  schema?: JSONSchema
+  /** Optional `$ref` definitions passed through to `createAjvValidator`. */
+  schemaDefinitions?: AjvValidatorOptions['schemaDefinitions']
+  /** Optional Ajv options passed through to `createAjvValidator`. */
+  ajvOptions?: AjvValidatorOptions['ajvOptions']
+}
+
+/**
+ * Resolve the effective validator:
+ * - an explicit `validator` wins;
+ * - otherwise a `schema` is compiled with `createAjvValidator`;
+ * - otherwise `undefined` (no validation — the wrapper's default behavior).
+ */
+export function buildJsonValidator(options: JsonValidatorOptions): Validator | undefined {
+  if (options.validator) return options.validator
+  if (options.schema) {
+    return createAjvValidator({
+      schema: options.schema,
+      schemaDefinitions: options.schemaDefinitions,
+      ajvOptions: options.ajvOptions,
+    })
+  }
+  return undefined
+}

--- a/packages/qdadm/tests/components/jsonValidator.test.js
+++ b/packages/qdadm/tests/components/jsonValidator.test.js
@@ -1,0 +1,44 @@
+/**
+ * Unit tests for buildJsonValidator — the VanillaJsonEditor schema/validator
+ * resolution helper (qdadm #1050).
+ *
+ * Run: npm test
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { buildJsonValidator } from '../../src/components/editors/jsonValidator'
+
+const schema = {
+  type: 'object',
+  required: ['name'],
+  properties: {
+    name: { type: 'string' },
+    age: { type: 'number' },
+  },
+}
+
+describe('buildJsonValidator', () => {
+  it('returns undefined when neither schema nor validator is given', () => {
+    expect(buildJsonValidator({})).toBeUndefined()
+  })
+
+  it('compiles a JSON Schema into a validator that flags invalid JSON', () => {
+    const validate = buildJsonValidator({ schema })
+    expect(typeof validate).toBe('function')
+    // missing required `name` + wrong type for `age`
+    const errors = validate({ age: 'not-a-number' })
+    expect(errors.length).toBeGreaterThan(0)
+  })
+
+  it('the compiled validator passes valid JSON (no errors)', () => {
+    const validate = buildJsonValidator({ schema })
+    expect(validate({ name: 'Dune', age: 1965 })).toEqual([])
+  })
+
+  it('a raw validator takes precedence over schema', () => {
+    const raw = vi.fn(() => [])
+    const validate = buildJsonValidator({ validator: raw, schema })
+    expect(validate).toBe(raw)
+    validate({ anything: true })
+    expect(raw).toHaveBeenCalledOnce()
+  })
+})


### PR DESCRIPTION
Implements **#1050** (raised from skybot's incident-rules JSON editor, #1046).

## What
`VanillaJsonEditor` now forwards vanilla-jsoneditor's native `validator`. New optional props:
- `:schema="<JSON Schema>"` — compiled via `createAjvValidator` (Ajv is bundled in vanilla-jsoneditor, **no new dependency**); errors highlighted live in tree/text.
- `:validator="<fn>"` — raw validator, **takes precedence** over `schema`.
- `:schema-definitions` / `:ajv-options` — passthrough to the Ajv validator.

None set → behavior unchanged (no validation). Schema/validator changes are reactive (`editor.updateProps`). Validation errors already surface through the existing `error` event + the editor status bar — nothing rewired.

## How
- Pure `buildJsonValidator()` helper (`jsonValidator.ts`) so resolution logic (raw > schema > none) is unit-testable without mounting the Svelte editor.
- Wrapper props + reactive watch.

## Validation
- `vue-tsc` + eslint clean.
- Tests: **67 files / 1950 passing** (incl. 4 new `buildJsonValidator` tests: none→undefined, schema flags invalid, valid passes, raw precedence).

`minor` changeset. Closes #1050.