### PR TITLE
feat(lookup): kernel-aware endpoint mode for useOptionsLookup (#1198)

### DIFF
--- a/.changeset/lookup-kernel-endpoint.md
+++ b/.changeset/lookup-kernel-endpoint.md
@@ -1,0 +1,12 @@
+---
+"@quazardous/qdadm": minor
+---
+
+`useOptionsLookup` endpoint mode is now kernel-aware (#1198) — the raw-fetch footgun is gone.
+
+- **New kernel option `apiClient`** (`HttpClient` or factory), provided as `qdadmApiClient`: `new Kernel({ apiClient: myAxios })`. New exports: `useApiClient()`, `resolveApiClient()`, `API_CLIENT_INJECTION_KEY`.
+- **Endpoint routing precedence**: `via: 'entityName'` (new option — that entity's `storage.request()`) > relative endpoint → kernel `apiClient` (base URL + auth applied, zero per-call wiring) > absolute URL → raw `fetch` + `headers` (escape hatch, unchanged) > relative without a registered client → legacy raw fetch **with a console warning**.
+- **Failed lookups are no longer silent**: non-JSON responses (HTML page), 401/403 and parse failures log a `console.warn` naming the endpoint and the likely cause.
+- `ScopeEditor` falls back to the kernel `apiClient` when no `apiAdapter` is injected (existing contract unchanged).
+
+Purely additive — existing `endpoint` + `headers` calls keep working.

--- a/docs/forms.md
+++ b/docs/forms.md
@@ -232,15 +232,26 @@ for composite values like `module:type`). The contract is only "binds the same
 | Source | Call | Yields |
 |---|---|---|
 | **Entity** | `useOptionsLookup({ entity: 'botPools', label: 'name', value: 'id' })` | Options from a registered `EntityManager` |
-| **Endpoint** | `useOptionsLookup({ endpoint: 'https://api…/task-types', headers, label, value })` | Options fetched from a raw URL |
+| **Endpoint** | `useOptionsLookup({ endpoint: '/api/task-types', label, value })` | Options fetched from an API endpoint |
 | **Static** | `useOptionsLookup({ static: ['a', 'b', 'c'] })` | A fixed in-memory list |
 
-> ⚠️ **`endpoint` mode is a raw `fetch`** — it does NOT go through your storage
-> adapter, so **no API base URL and no auth header** are applied. In a typical
-> admin SPA (API on another origin, bearer auth) a relative endpoint hits the
-> admin origin unauthenticated and the autocomplete comes back empty. Prefer
-> **`entity`** (or `static`); if you must use `endpoint`, pass an **absolute URL**
-> and the auth via the `headers` option (a `Record` or a `() => Record` callback).
+**Endpoint routing** *(since 2.1)* — register your API client once on the kernel
+and relative endpoints Just Work (base URL + auth applied):
+
+```js
+new Kernel({ apiClient: myAxios })   // the same client your ApiStorages use
+```
+
+| Endpoint shape | Routed through |
+|---|---|
+| `via: 'entityName'` set | That entity's `storage.request()` (explicit, multi-API apps) |
+| Relative (`/api/…`) | The kernel `apiClient` → base URL + auth, zero per-call wiring |
+| Absolute (`https://…`) | Raw `fetch` + optional `headers` — the escape hatch for third-party APIs |
+| Relative, **no** `apiClient` registered | Legacy raw fetch + a console warning |
+
+Failed lookups are always diagnosable: a non-JSON response (HTML page), 401/403,
+or a parse failure logs a `console.warn` naming the endpoint and the likely
+cause — an empty autocomplete is never silent.
 
 Omit `label`/`value` for a **pure** `string[]`/`number[]` source (suggestions are
 the raw values); provide them for **mapped** mode when items are objects and the

--- a/packages/qdadm/src/api/apiClient.ts
+++ b/packages/qdadm/src/api/apiClient.ts
@@ -1,0 +1,34 @@
+/**
+ * Kernel-level default API client (qdadm #1198)
+ *
+ * Apps already build an axios-compatible HttpClient (base URL + auth
+ * interceptors) for their ApiStorages. Registering it once on the kernel
+ * makes it available to composables/widgets that need ad-hoc API calls
+ * (useOptionsLookup endpoint mode, ScopeEditor), so relative endpoints
+ * get base URL + auth applied without per-call wiring:
+ *
+ *   new Kernel({ apiClient: myAxios })
+ */
+import { inject } from 'vue'
+import type { HttpClient } from '../entity/storage/ApiStorage'
+
+/** Injection key under which the kernel provides the default API client. */
+export const API_CLIENT_INJECTION_KEY = 'qdadmApiClient'
+
+/** Accepted forms of the kernel `apiClient` option. */
+export type ApiClientSource = HttpClient | (() => HttpClient)
+
+/** Resolve an ApiClientSource (direct instance or factory) to a client. */
+export function resolveApiClient(source: ApiClientSource | null | undefined): HttpClient | null {
+  if (!source) return null
+  return typeof source === 'function' ? source() : source
+}
+
+/**
+ * Inject the kernel-registered default API client, or null when none is
+ * registered. Must be called from a setup context (like any inject).
+ */
+export function useApiClient(): HttpClient | null {
+  const source = inject<ApiClientSource | null>(API_CLIENT_INJECTION_KEY, null)
+  return resolveApiClient(source)
+}

--- a/packages/qdadm/src/components/editors/ScopeEditor.vue
+++ b/packages/qdadm/src/components/editors/ScopeEditor.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, watch, inject } from 'vue'
+import type { HttpClient } from '../../entity/storage/ApiStorage'
 import AutoComplete from 'primevue/autocomplete'
 import Select from 'primevue/select'
 import Button from 'primevue/button'
@@ -43,8 +44,10 @@ const props = withDefaults(defineProps<Props>(), {
   defaultActions: null
 })
 
-// Get API adapter (optional)
+// Get API adapter (optional); the kernel default client (Kernel({ apiClient }))
+// serves as fallback so scope endpoints get base URL + auth without app wiring.
 const api = inject<ApiAdapter | null>('apiAdapter', null)
+const kernelApiClient = inject<HttpClient | (() => HttpClient) | null>('qdadmApiClient', null)
 
 // Get global scope config (optional) - allows app-level configuration
 const globalScopeConfig = inject<ScopeConfig>('scopeConfig', {})
@@ -178,8 +181,17 @@ function isRowComplete(row: ScopeRow): boolean {
 async function loadScopeDefinition(): Promise<void> {
   loading.value = true
   try {
-    if (!api) {
-      // No API adapter, use defaults
+    let data: ScopeDefinition | null = null
+    if (api) {
+      data = await api.request('GET', config.value.endpoint)
+    } else if (kernelApiClient) {
+      // Fallback: kernel default API client (base URL + auth applied)
+      const client = typeof kernelApiClient === 'function' ? kernelApiClient() : kernelApiClient
+      data = (await client.get<ScopeDefinition>(config.value.endpoint)).data
+    }
+
+    if (!data) {
+      // No API layer available, use defaults
       scopeDefinition.value = {
         resources: [...config.value.resources],
         actions: [...config.value.actions],
@@ -187,7 +199,6 @@ async function loadScopeDefinition(): Promise<void> {
       return
     }
 
-    const data = await api.request('GET', config.value.endpoint)
     scopeDefinition.value = {
       resources: data.resources || [...config.value.resources],
       actions: data.actions || [...config.value.actions],

--- a/packages/qdadm/src/composables/useOptionsLookup.ts
+++ b/packages/qdadm/src/composables/useOptionsLookup.ts
@@ -42,6 +42,7 @@
  */
 import { ref, onMounted, type Ref } from 'vue'
 import { useOrchestrator } from '../orchestrator/useOrchestrator.js'
+import { useApiClient } from '../api/apiClient'
 
 export interface OptionsLookupItem {
   label: string
@@ -66,11 +67,27 @@ export interface UseOptionsLookupConfig {
   entity?: string
   /** Extract distinct values from a specific field (entity mode only) */
   field?: string
-  /** Fetch options from a raw API endpoint */
+  /**
+   * Fetch options from an API endpoint.
+   *
+   * Routing (#1198): a **relative** endpoint goes through the kernel's
+   * default API client when one is registered (`Kernel({ apiClient })`) —
+   * base URL + auth applied, no per-call wiring. An **absolute** URL is
+   * fetched raw (escape hatch for third-party APIs, combine with `headers`).
+   * A relative endpoint with no registered client falls back to a raw fetch
+   * (legacy) with a console warning.
+   */
   endpoint?: string
+  /**
+   * Route the endpoint request through the named entity's storage
+   * (`storage.request('GET', endpoint)`) instead of the kernel client —
+   * explicit refinement for multi-API apps. Takes precedence over the
+   * kernel client.
+   */
+  via?: string
   /** When using endpoint: pick a sub-key from the response data */
   pick?: string
-  /** Extra headers for endpoint fetch (e.g. Authorization) */
+  /** Extra headers for the raw-fetch paths (e.g. Authorization) */
   headers?: Record<string, string> | (() => Record<string, string>)
   /** Static options (no fetch needed) */
   static?: unknown[]
@@ -164,10 +181,16 @@ export function useOptionsLookup(config: UseOptionsLookupConfig): UseOptionsLook
       : defaultDecode
   )
 
-  // Resolve orchestrator lazily (only if entity mode)
-  let getManager: ((name: string) => { list: (params?: Record<string, unknown>) => Promise<{ items: unknown[] }> }) | null = null
+  // Resolve orchestrator lazily (entity mode, or via:'entityName' routing)
+  type LookupManager = {
+    list: (params?: Record<string, unknown>) => Promise<{ items: unknown[] }>
+    storage?: {
+      request?: (method: string, path: string, options?: Record<string, unknown>) => Promise<unknown>
+    }
+  }
+  let getManager: ((name: string) => LookupManager) | null = null
 
-  if (config.entity) {
+  if (config.entity || config.via) {
     try {
       const orc = useOrchestrator()
       // Generic-vs-non-generic: getManager is parameterised by an
@@ -178,6 +201,105 @@ export function useOptionsLookup(config: UseOptionsLookupConfig): UseOptionsLook
     } catch {
       // Orchestrator not available
     }
+  }
+
+  // Kernel default API client (Kernel({ apiClient })) — used for relative
+  // endpoints so base URL + auth apply without per-call wiring (#1198).
+  let apiClient: ReturnType<typeof useApiClient> = null
+  if (config.endpoint) {
+    try {
+      apiClient = useApiClient()
+    } catch {
+      // Outside a setup/injection context
+    }
+  }
+
+  // Bare-relative warning: once per composable instance, not per load
+  let warnedBareRelative = false
+
+  function warnLookup(msg: string): void {
+    console.warn(`[qdadm] useOptionsLookup(endpoint: '${config.endpoint}'): ${msg}`)
+  }
+
+  /** Shared normalization for every endpoint path: unwrap data, pick, array-check. */
+  function normalizeEndpointPayload(json: unknown): unknown[] {
+    let data: unknown = (json as { data?: unknown })?.data ?? json
+    if (config.pick && typeof data === 'object' && data !== null && !Array.isArray(data)) {
+      data = (data as Record<string, unknown>)[config.pick]
+    }
+    if (!Array.isArray(data)) {
+      warnLookup('response contained no usable array (after data/pick unwrap) — check the endpoint payload shape')
+      return []
+    }
+    return data
+  }
+
+  /** Endpoint routing (#1198): via storage > relative→kernel client > raw fetch. */
+  async function loadFromEndpoint(): Promise<unknown[]> {
+    const endpoint = config.endpoint!
+    const isAbsolute = /^https?:\/\//i.test(endpoint)
+
+    // 1. via:'entityName' → that entity's storage (explicit refinement)
+    if (config.via && getManager) {
+      const storage = getManager(config.via)?.storage
+      if (storage?.request) {
+        try {
+          const json = await storage.request('GET', endpoint)
+          return normalizeEndpointPayload(json)
+        } catch (err) {
+          warnLookup(`request via '${config.via}' storage failed: ${err instanceof Error ? err.message : err}`)
+          throw err
+        }
+      }
+      warnLookup(`via: '${config.via}' has no storage.request() — falling back to the default routing`)
+    }
+
+    // 2. relative endpoint → kernel default API client (base URL + auth)
+    if (!isAbsolute && apiClient) {
+      try {
+        const { data } = await apiClient.get(endpoint)
+        return normalizeEndpointPayload(data)
+      } catch (err) {
+        warnLookup(`request through the kernel apiClient failed: ${err instanceof Error ? err.message : err}`)
+        throw err
+      }
+    }
+
+    // 3. raw fetch — absolute URL (escape hatch) or legacy relative call
+    if (!isAbsolute && !warnedBareRelative) {
+      warnedBareRelative = true
+      warnLookup(
+        'relative endpoint fetched bare — no API base URL or auth header applied. ' +
+        'Register Kernel({ apiClient }) (recommended), use via: \'entityName\', or pass an absolute URL + headers.'
+      )
+    }
+    const extraHeaders = typeof config.headers === 'function' ? config.headers() : config.headers
+    const response = await fetch(endpoint, {
+      credentials: 'include',
+      headers: { 'Accept': 'application/json', ...extraHeaders },
+    })
+    if (!response.ok) {
+      const authHint = response.status === 401 || response.status === 403
+        ? ' — missing auth? register Kernel({ apiClient }) or pass headers'
+        : ''
+      warnLookup(`HTTP ${response.status}${authHint}`)
+      throw new Error(`HTTP ${response.status}`)
+    }
+    const contentType = response.headers.get('content-type') || ''
+    if (!contentType.includes('json')) {
+      warnLookup(
+        `response is not JSON (content-type: '${contentType || 'unknown'}') — the relative URL likely resolved ` +
+        'to the app origin (HTML page). Register Kernel({ apiClient }) or use an absolute URL.'
+      )
+    }
+    let json: unknown
+    try {
+      json = await response.json()
+    } catch (err) {
+      warnLookup(`response body is not parseable JSON: ${err instanceof Error ? err.message : err}`)
+      throw err
+    }
+    return normalizeEndpointPayload(json)
   }
 
   // Encoded strings cache for mapped mode (rebuilt on processItems)
@@ -255,21 +377,7 @@ export function useOptionsLookup(config: UseOptionsLookupConfig): UseOptionsLook
           items = rawItems
         }
       } else if (config.endpoint) {
-        const extraHeaders = typeof config.headers === 'function' ? config.headers() : config.headers
-        const response = await fetch(config.endpoint, {
-          credentials: 'include',
-          headers: { 'Accept': 'application/json', ...extraHeaders },
-        })
-        if (!response.ok) throw new Error(`HTTP ${response.status}`)
-        const json = await response.json()
-
-        let data = json.data ?? json
-
-        if (config.pick && typeof data === 'object' && !Array.isArray(data)) {
-          data = (data as Record<string, unknown>)[config.pick]
-        }
-
-        items = Array.isArray(data) ? data : []
+        items = await loadFromEndpoint()
       }
 
       processItems(items)

--- a/packages/qdadm/src/index.ts
+++ b/packages/qdadm/src/index.ts
@@ -293,6 +293,12 @@ export {
   type OptionsLookupItem,
   type OptionsDisplayMode,
 } from './composables/useOptionsLookup'
+export {
+  useApiClient,
+  resolveApiClient,
+  API_CLIENT_INJECTION_KEY,
+  type ApiClientSource,
+} from './api/apiClient'
 export { useChildPage, type UseChildPageReturn } from './composables/useChildPage'
 export { useSidebarState, SIDEBAR_COLLAPSED_KEY } from './composables/useSidebarState'
 

--- a/packages/qdadm/src/kernel/Kernel.types.ts
+++ b/packages/qdadm/src/kernel/Kernel.types.ts
@@ -11,6 +11,7 @@ import type { EntityManager } from '../entity/EntityManager'
 import type { EntityAuthAdapter } from '../entity/auth/EntityAuthAdapter'
 import type { RoleProvider } from '../security/RolesProvider'
 import type { I18nOptions } from '../i18n/types'
+import type { ApiClientSource } from '../api/apiClient'
 
 /**
  * Auth adapter interface (app-level authentication)
@@ -183,6 +184,14 @@ export interface KernelOptions {
   debug?: boolean
   onAuthExpired?: (payload: unknown) => void
   i18n?: I18nOptions
+  /**
+   * Default API HTTP client (axios-compatible `HttpClient`, or a factory),
+   * provided to composables/widgets as `qdadmApiClient`. Relative-endpoint
+   * lookups (`useOptionsLookup` endpoint mode, `ScopeEditor` fallback) route
+   * through it so the app's base URL + auth headers apply without per-call
+   * wiring. Typically the same client your ApiStorages use.
+   */
+  apiClient?: ApiClientSource
   /**
    * Existing Vue app to install qdadm onto. When provided, the Kernel
    * skips its own `createApp(WrappedRoot)` and reuses the supplied

--- a/packages/qdadm/src/kernel/Kernel.vue.ts
+++ b/packages/qdadm/src/kernel/Kernel.vue.ts
@@ -205,6 +205,12 @@ export function applyVueMethods(KernelClass: { prototype: any }): void {
     app.provide('qdadmActiveStack', this.activeStack)
     app.provide('qdadmStackHydrator', this.stackHydrator)
 
+    if (this.options.apiClient) {
+      // Default API client for composables/widgets (useOptionsLookup,
+      // ScopeEditor) — relative endpoints get base URL + auth (#1198).
+      app.provide('qdadmApiClient', this.options.apiClient)
+    }
+
     if (this.options.debug && typeof window !== 'undefined') {
       const self = this
       // Single namespaced surface for browser-console & agent introspection.

--- a/packages/qdadm/tests/composables/useOptionsLookup.endpoint.test.js
+++ b/packages/qdadm/tests/composables/useOptionsLookup.endpoint.test.js
@@ -1,0 +1,153 @@
+/**
+ * Unit tests for useOptionsLookup endpoint routing (qdadm #1198).
+ *
+ * Precedence: via:'entityName' storage > relative endpoint → kernel
+ * apiClient (base URL + auth) > raw fetch (absolute URL escape hatch, or
+ * legacy relative call with a warning).
+ *
+ * Run: npm test
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { defineComponent } from 'vue'
+import { useOptionsLookup } from '../../src/composables/useOptionsLookup'
+
+const ITEMS = [
+  { id: 't1', name: 'Type One' },
+  { id: 't2', name: 'Type Two' },
+]
+
+function mountLookup(config, provide = {}) {
+  let lookup
+  const Comp = defineComponent({
+    setup() {
+      lookup = useOptionsLookup(config)
+      return () => null
+    },
+  })
+  const wrapper = mount(Comp, { global: { provide } })
+  return { get lookup() { return lookup }, wrapper }
+}
+
+function fetchResponse(body, { status = 200, contentType = 'application/json' } = {}) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: { get: (k) => (k.toLowerCase() === 'content-type' ? contentType : null) },
+    json: async () => {
+      if (typeof body === 'string') throw new Error('Unexpected token <')
+      return body
+    },
+  }
+}
+
+let warnSpy
+let fetchMock
+
+beforeEach(() => {
+  warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+  fetchMock = vi.fn(async () => fetchResponse({ data: ITEMS }))
+  vi.stubGlobal('fetch', fetchMock)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+describe('useOptionsLookup — endpoint routing (#1198)', () => {
+  it('routes a RELATIVE endpoint through the kernel apiClient (no raw fetch, no warn)', async () => {
+    const client = { get: vi.fn(async () => ({ data: { data: ITEMS } })) }
+    const ctx = mountLookup(
+      { endpoint: '/api/admin/task-types', label: 'name', value: 'id' },
+      { qdadmApiClient: client },
+    )
+    await flushPromises()
+
+    expect(client.get).toHaveBeenCalledWith('/api/admin/task-types')
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(ctx.lookup.options.value).toEqual([
+      { label: 'Type One', value: 't1' },
+      { label: 'Type Two', value: 't2' },
+    ])
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+
+  it('accepts a factory as apiClient source', async () => {
+    const client = { get: vi.fn(async () => ({ data: ITEMS })) }
+    const ctx = mountLookup(
+      { endpoint: '/api/tags' },
+      { qdadmApiClient: () => client },
+    )
+    await flushPromises()
+
+    expect(client.get).toHaveBeenCalledWith('/api/tags')
+    expect(ctx.lookup.error.value).toBeNull()
+  })
+
+  it('fetches an ABSOLUTE URL raw even when a kernel client is registered (escape hatch)', async () => {
+    const client = { get: vi.fn() }
+    mountLookup(
+      { endpoint: 'https://api.example.com/things', headers: { Authorization: 'Bearer x' } },
+      { qdadmApiClient: client },
+    )
+    await flushPromises()
+
+    expect(client.get).not.toHaveBeenCalled()
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe('https://api.example.com/things')
+    expect(init.headers.Authorization).toBe('Bearer x')
+  })
+
+  it("routes through via:'entityName' storage.request in priority over the kernel client", async () => {
+    const request = vi.fn(async () => ({ data: ITEMS }))
+    // useOrchestrator wraps the injected orchestrator: getManager → orchestrator.get(name)
+    const orchestrator = { get: () => ({ storage: { request } }), has: () => true }
+    const client = { get: vi.fn() }
+    const ctx = mountLookup(
+      { endpoint: '/api/admin/task-types', via: 'catalog', label: 'name', value: 'id' },
+      { qdadmOrchestrator: orchestrator, qdadmApiClient: client },
+    )
+    await flushPromises()
+
+    expect(request).toHaveBeenCalledWith('GET', '/api/admin/task-types')
+    expect(client.get).not.toHaveBeenCalled()
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(ctx.lookup.options.value).toHaveLength(2)
+  })
+
+  it('falls back to a bare fetch for a relative endpoint with NO kernel client — and warns', async () => {
+    const ctx = mountLookup({ endpoint: '/api/legacy' })
+    await flushPromises()
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(ctx.lookup.options.value).toHaveLength(2)
+    const warned = warnSpy.mock.calls.map((c) => c[0]).join('\n')
+    expect(warned).toContain('fetched bare')
+    expect(warned).toContain('Kernel({ apiClient })')
+  })
+
+  it('warns with an auth hint on 401 (raw path) and sets the error ref', async () => {
+    fetchMock.mockResolvedValueOnce(fetchResponse({}, { status: 401 }))
+    const ctx = mountLookup({ endpoint: 'https://api.example.com/secure' })
+    await flushPromises()
+
+    expect(ctx.lookup.error.value).toBe('HTTP 401')
+    const warned = warnSpy.mock.calls.map((c) => c[0]).join('\n')
+    expect(warned).toContain('HTTP 401')
+    expect(warned).toContain('missing auth')
+  })
+
+  it('warns when the response is not JSON (HTML page case)', async () => {
+    fetchMock.mockResolvedValueOnce(
+      fetchResponse('<!doctype html>', { contentType: 'text/html' }),
+    )
+    const ctx = mountLookup({ endpoint: 'https://app.example.com/api/oops' })
+    await flushPromises()
+
+    const warned = warnSpy.mock.calls.map((c) => c[0]).join('\n')
+    expect(warned).toContain('not JSON')
+    expect(ctx.lookup.error.value).not.toBeNull()
+  })
+})


### PR DESCRIPTION
Executes the accepted plan on aiball #1198 (stakeholder-endorsed design).

## What
The naive `useOptionsLookup({ endpoint: '/api/…' })` call now Just Works: relative endpoints route through the kernel's default API client, so base URL + auth apply with **zero per-call wiring**.

```js
new Kernel({ apiClient: myAxios })   // one line — same client your ApiStorages use
```

## Routing precedence
1. `via: 'entityName'` (new option) → that entity's `storage.request('GET', endpoint)` — explicit refinement for multi-API apps
2. **Relative URL** → injected `qdadmApiClient` (kills the footgun)
3. **Absolute URL** → raw `fetch` + `headers` — the escape hatch, unchanged
4. Relative with **no** registered client → legacy raw fetch **+ console warning** (graceful migration path)

## Visibility (non-optional, per testbed feedback)
Non-JSON responses (the HTML-page case), 401/403 (with an auth hint) and parse failures all `console.warn` with the endpoint and probable cause — an empty autocomplete is never silent again.

## Also
- `ScopeEditor` falls back to `qdadmApiClient` when its app-provided `apiAdapter` inject is absent (existing contract kept).
- New exports: `useApiClient()`, `resolveApiClient()`, `API_CLIENT_INJECTION_KEY`, `ApiClientSource`.
- forms.md endpoint section rewritten for the new default (routing table).

## Safety
- **7 new routing tests** (client vs fetch vs via precedence, factory form, bare-relative warn, 401 hint, HTML warn) — mocked client/orchestrator/fetch, no network.
- Full suite **1935 green**, `vue-tsc` clean, 0 new eslint issues on touched files.
- Purely additive → changeset **minor** (2.1.0).

aiball: #1198 (plan g8mz88 accepted; skybot to re-run their live repro post-ship).