### PR TITLE
fix(routing): namespace parent param in two-id child route families (#1201)

### DIFF
--- a/.changeset/child-route-param-collision.md
+++ b/.changeset/child-route-param-collision.md
@@ -1,0 +1,13 @@
+---
+"@quazardous/qdadm": minor
+---
+
+Fix the child-route `:id` collision (#1201): `ctx.crud(child, { show/form }, { parentRoute })` generated `parent/:id/child/:id` when parent and child both used `idField: 'id'` — the child param shadowed the parent, breaking parent resolution (breadcrumb, parentChain, FK filter) on every child show/edit page.
+
+**New naming policy (`parentParamMode: 'auto'`, default):**
+- List-only child families keep the bare param — `/jobs/:id/tasks` URLs are **unchanged**.
+- Families with show/edit routes namespace the parent and keep the principal (child) id bare: `/jobs/:jobId/tasks/:id`.
+
+**Overrides** (by precedence): per-call `CrudOptions.parentParam` (e.g. `'jobUuid'`) > kernel `routeParamResolver(ctx)` global mapping service > kernel `parentParamMode` (`'auto' | 'always' | 'bare'`; `bare` = legacy naming with an explicit registration error on collision instead of silent shadowing).
+
+Framework consumers read the resolved name from `route.meta.parent.param`, so breadcrumbs, parent chains and FK filters adapt automatically. Only app code reading `route.params.id` directly in a child show/edit page to get the **parent** id needs updating — that pattern was broken by the shadowing anyway.

--- a/docs/crud.md
+++ b/docs/crud.md
@@ -56,6 +56,7 @@ Use `form` for the single-form pattern (recommended). Use `create`/`edit` only w
 | `parentRoute` | `string` | Mount as child of this route (e.g. `'book'`) |
 | `foreignKey` | `string` | FK field linking child to parent (e.g. `'book_id'`) |
 | `label` | `string` | Tab label for child route (e.g. `'Loans'`) |
+| `parentParam` | `string` | Explicit URL param name for the parent id (overrides the naming policy below) |
 | `routePrefix` | `string` | Override route name prefix |
 | `pathSegment` | `string` | Override URL path (e.g. `'tasks'` instead of `'job-tasks'`) |
 
@@ -523,6 +524,17 @@ list.addDeleteAction()
 - Parent filter injected: `loans.list({ book_id: bookId })`
 - Breadcrumb: Books > Book Title > Loans
 - Tab navigation via `<PageNav />`
+
+**Parent param naming** *(since 2.2)*: the URL param carrying the parent id must
+not collide with the child's own `:id`. The default policy (`auto`) keeps the
+bare `idField` param for **list-only** families (`/jobs/:id/tasks`, unchanged
+URLs) and namespaces the parent as soon as the family has a **show/edit** route
+(`/jobs/:jobId/tasks/:id` — the principal, child id stays `:id`). Overrides,
+by precedence: per-call `parentParam` > kernel `routeParamResolver` (global
+mapping service) > kernel `parentParamMode` (`auto` | `always` | `bare`; `bare`
+throws an explicit error on collision instead of silently shadowing the parent).
+Framework consumers (breadcrumb, parent chain, FK filter) read the resolved name
+from `route.meta.parent.param` — no page code change needed.
 
 ### Child form
 

--- a/packages/qdadm/src/kernel/Kernel.types.ts
+++ b/packages/qdadm/src/kernel/Kernel.types.ts
@@ -193,6 +193,26 @@ export interface KernelOptions {
    */
   apiClient?: ApiClientSource
   /**
+   * Naming policy for the URL param carrying the parent id in child route
+   * families (#1201). `auto` (default): list-only families keep the bare
+   * `idField` param; families with show/edit routes namespace the parent
+   * (`jobs/:jobId/tasks/:id`) so the principal (child) id stays `:id`.
+   * `always`: namespaced everywhere. `bare`: legacy `idField` param, with
+   * an explicit registration error on collision.
+   */
+  parentParamMode?: 'auto' | 'always' | 'bare'
+  /**
+   * Global mapping service for parent URL param names (#1201). Consulted
+   * before `parentParamMode`; a per-call `parentParam` still wins. Return
+   * undefined to fall through to the mode-based default.
+   */
+  routeParamResolver?: (ctx: {
+    parentEntity: string
+    parentRouteName: string
+    childEntity: string | null
+    parentIdField: string
+  }) => string | undefined
+  /**
    * Existing Vue app to install qdadm onto. When provided, the Kernel
    * skips its own `createApp(WrappedRoot)` and reuses the supplied
    * instance — useful when a host shell (e.g. a CMS) already owns the

--- a/packages/qdadm/src/kernel/KernelContext.routing.ts
+++ b/packages/qdadm/src/kernel/KernelContext.routing.ts
@@ -45,6 +45,89 @@ function capitalize(str: string): string {
   return str.charAt(0).toUpperCase() + str.slice(1)
 }
 
+/** Context handed to a kernel-level routeParamResolver (#1201). */
+export interface RouteParamResolverContext {
+  parentEntity: string
+  parentRouteName: string
+  /** Child entity name, or null for a non-entity childPage. */
+  childEntity: string | null
+  parentIdField: string
+}
+
+/**
+ * Resolve the URL param name carrying the parent id in a child route
+ * family (#1201). Precedence: per-call `parentParam` > kernel
+ * `routeParamResolver` > `parentParamMode`:
+ *
+ * - `auto` (default): families whose routes never carry the child's own
+ *   id (list-only, childPage) keep the bare parent `idField` param —
+ *   unchanged URLs. Families with show/edit routes namespace the parent
+ *   (`:jobId`) so the principal (child) id stays `:id`.
+ * - `always`: namespaced parent param everywhere.
+ * - `bare`: legacy `idField` param everywhere; a would-be collision
+ *   throws at registration instead of silently shadowing the parent.
+ */
+function resolveParentParam(opts: {
+  kernelOptions?: {
+    parentParamMode?: 'auto' | 'always' | 'bare'
+    routeParamResolver?: (ctx: RouteParamResolverContext) => string | undefined
+  }
+  explicit?: string
+  parentEntity: string
+  parentRouteName: string
+  childEntity: string | null
+  parentIdField: string
+  childIdParam: string
+  hasOwnIdParam: boolean
+}): string {
+  const {
+    kernelOptions,
+    explicit,
+    parentEntity,
+    parentRouteName,
+    childEntity,
+    parentIdField,
+    childIdParam,
+    hasOwnIdParam,
+  } = opts
+
+  if (explicit) return explicit
+
+  const resolved = kernelOptions?.routeParamResolver?.({
+    parentEntity,
+    parentRouteName,
+    childEntity,
+    parentIdField,
+  })
+  if (resolved) return resolved
+
+  const mode = kernelOptions?.parentParamMode || 'auto'
+  const namespaced = `${singularize(parentEntity)}Id`
+
+  if (mode === 'always') return namespaced
+
+  if (mode === 'bare') {
+    if (hasOwnIdParam && parentIdField === childIdParam) {
+      throw new Error(
+        `[qdadm] crud('${childEntity}', { parentRoute: '${parentRouteName}' }): parent and child ` +
+        `both use the URL param ':${childIdParam}' — the child id would shadow the parent id. ` +
+        `Switch parentParamMode to 'auto', or set an explicit parentParam.`
+      )
+    }
+    return parentIdField
+  }
+
+  // mode === 'auto'
+  if (!hasOwnIdParam) return parentIdField
+  if (namespaced === childIdParam) {
+    throw new Error(
+      `[qdadm] crud('${childEntity}', { parentRoute: '${parentRouteName}' }): the namespaced ` +
+      `parent param ':${namespaced}' collides with the child idField — set an explicit parentParam.`
+    )
+  }
+  return namespaced
+}
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function applyRoutingMethods(KernelContextClass: { prototype: any }): void {
   const proto = KernelContextClass.prototype as Self
@@ -103,7 +186,20 @@ export function applyRoutingMethods(KernelContextClass: { prototype: any }): voi
         const parentManager = parentEntityName
           ? this._kernel.orchestrator?.get(parentEntityName)
           : null
-        const parentIdParam = parentManager?.idField || 'id'
+        const parentIdField = parentManager?.idField || 'id'
+        // Families with show/edit routes carry the child's own :id — the
+        // parent param must not collide with it (#1201).
+        const hasOwnIdParam = !!(pages.show || pages.form || pages.edit)
+        const parentIdParam = resolveParentParam({
+          kernelOptions: this._kernel.options,
+          explicit: options.parentParam,
+          parentEntity: parentEntityName || parentRouteName,
+          parentRouteName,
+          childEntity: entity,
+          parentIdField,
+          childIdParam: idParam,
+          hasOwnIdParam,
+        })
 
         // Build base path: parentPath/:parentId/entity (e.g., books/:bookId/loans)
         const parentBasePath =
@@ -238,7 +334,19 @@ export function applyRoutingMethods(KernelContextClass: { prototype: any }): voi
     const parentManager = parentEntityName
       ? this._kernel.orchestrator?.get(parentEntityName)
       : null
-    const parentIdParam = parentManager?.idField || 'id'
+    const parentIdField = parentManager?.idField || 'id'
+    // childPage has no own :id (single-id family) — auto mode keeps the
+    // bare param; explicit parentParam / resolver / 'always' still apply.
+    const parentIdParam = resolveParentParam({
+      kernelOptions: this._kernel.options,
+      explicit: options.parentParam,
+      parentEntity: parentEntityName || parentRouteName,
+      parentRouteName,
+      childEntity: null,
+      parentIdField,
+      childIdParam: 'id',
+      hasOwnIdParam: false,
+    })
 
     const parentBasePath =
       parentRoute.path.replace(/\/(create|:.*)?$/, '') || parentEntityName

--- a/packages/qdadm/src/kernel/KernelContext.types.ts
+++ b/packages/qdadm/src/kernel/KernelContext.types.ts
@@ -148,6 +148,12 @@ export interface CrudOptions {
   parentRoute?: string
   foreignKey?: string
   label?: string
+  /**
+   * Explicit URL param name carrying the parent id in child routes
+   * (e.g. 'jobUuid' → `jobs/:jobUuid/tasks/:id`). Overrides the kernel
+   * `routeParamResolver` and `parentParamMode` (#1201).
+   */
+  parentParam?: string
 }
 
 /** Child page options for non-entity child routes */
@@ -156,6 +162,8 @@ export interface ChildPageOptions {
   label?: string
   icon?: string
   meta?: Record<string, unknown>
+  /** Explicit URL param name for the parent id (see CrudOptions.parentParam). */
+  parentParam?: string
 }
 
 /** User entity options */

--- a/packages/qdadm/tests/kernel/KernelContext.routing.params.test.js
+++ b/packages/qdadm/tests/kernel/KernelContext.routing.params.test.js
@@ -1,0 +1,135 @@
+/**
+ * Unit tests for child-route parent param resolution (qdadm #1201).
+ *
+ * The parent id URL param must not collide with the child's own :id.
+ * Precedence: per-call parentParam > kernel routeParamResolver >
+ * parentParamMode (auto | always | bare).
+ *
+ * NOTE: the module registry is global — every test uses unique entity
+ * names to stay isolated.
+ *
+ * Run: npm test
+ */
+import { describe, it, expect } from 'vitest'
+import { KernelContext } from '../../src/kernel/KernelContext'
+import { Module } from '../../src/kernel/Module'
+import { getRoutes } from '../../src/module/moduleRegistry'
+
+const noopPage = () => Promise.resolve({ default: {} })
+
+function makeCtx(kernelOptions = {}) {
+  const kernel = {
+    orchestrator: {
+      isRegistered: () => true,
+      get: () => ({ idField: 'id' }),
+    },
+    options: kernelOptions,
+    _pendingProvides: new Map(),
+    _pendingComponents: new Map(),
+  }
+  return new KernelContext(kernel, new Module())
+}
+
+function findRoute(name) {
+  return getRoutes().find((r) => r.name === name)
+}
+
+describe('child-route parent param resolution (#1201)', () => {
+  it('auto mode: family WITH show namespaces the parent, child keeps :id', () => {
+    const ctx = makeCtx()
+    ctx.crud('p1jobs', { list: noopPage })
+    ctx.crud('p1tasks', { list: noopPage, show: noopPage }, { parentRoute: 'p1job' })
+
+    const list = findRoute('p1job-p1task')
+    const show = findRoute('p1job-p1task-show')
+    expect(list.path).toBe('p1jobs/:p1jobId/p1tasks')
+    expect(show.path).toBe('p1jobs/:p1jobId/p1tasks/:id')
+    expect(show.meta.parent.param).toBe('p1jobId')
+  })
+
+  it('auto mode: list-only family falls back to the bare :id (unchanged URLs)', () => {
+    const ctx = makeCtx()
+    ctx.crud('p2jobs', { list: noopPage })
+    ctx.crud('p2tasks', { list: noopPage }, { parentRoute: 'p2job' })
+
+    const list = findRoute('p2job-p2task')
+    expect(list.path).toBe('p2jobs/:id/p2tasks')
+    expect(list.meta.parent.param).toBe('id')
+  })
+
+  it('auto mode: form family (create/edit) namespaces the parent too', () => {
+    const ctx = makeCtx()
+    ctx.crud('p3jobs', { list: noopPage })
+    ctx.crud('p3tasks', { list: noopPage, form: noopPage }, { parentRoute: 'p3job' })
+
+    const edit = findRoute('p3job-p3task-edit')
+    expect(edit.path).toBe('p3jobs/:p3jobId/p3tasks/:id/edit')
+    expect(edit.meta.parent.param).toBe('p3jobId')
+  })
+
+  it('per-call parentParam overrides everything', () => {
+    const ctx = makeCtx({
+      parentParamMode: 'bare',
+      routeParamResolver: () => 'resolverWins',
+    })
+    ctx.crud('p4jobs', { list: noopPage })
+    ctx.crud(
+      'p4tasks',
+      { list: noopPage, show: noopPage },
+      { parentRoute: 'p4job', parentParam: 'jobUuid' },
+    )
+
+    const show = findRoute('p4job-p4task-show')
+    expect(show.path).toBe('p4jobs/:jobUuid/p4tasks/:id')
+    expect(show.meta.parent.param).toBe('jobUuid')
+  })
+
+  it('kernel routeParamResolver wins over the mode default', () => {
+    const seen = []
+    const ctx = makeCtx({
+      routeParamResolver: (rctx) => {
+        seen.push(rctx)
+        return 'mappedId'
+      },
+    })
+    ctx.crud('p5jobs', { list: noopPage })
+    ctx.crud('p5tasks', { list: noopPage, show: noopPage }, { parentRoute: 'p5job' })
+
+    const show = findRoute('p5job-p5task-show')
+    expect(show.path).toBe('p5jobs/:mappedId/p5tasks/:id')
+    expect(seen[0]).toEqual({
+      parentEntity: 'p5jobs',
+      parentRouteName: 'p5job',
+      childEntity: 'p5tasks',
+      parentIdField: 'id',
+    })
+  })
+
+  it("mode 'always' namespaces even a list-only family", () => {
+    const ctx = makeCtx({ parentParamMode: 'always' })
+    ctx.crud('p6jobs', { list: noopPage })
+    ctx.crud('p6tasks', { list: noopPage }, { parentRoute: 'p6job' })
+
+    const list = findRoute('p6job-p6task')
+    expect(list.path).toBe('p6jobs/:p6jobId/p6tasks')
+    expect(list.meta.parent.param).toBe('p6jobId')
+  })
+
+  it("mode 'bare' throws an explicit error on collision instead of shadowing", () => {
+    const ctx = makeCtx({ parentParamMode: 'bare' })
+    ctx.crud('p7jobs', { list: noopPage })
+    expect(() =>
+      ctx.crud('p7tasks', { list: noopPage, show: noopPage }, { parentRoute: 'p7job' }),
+    ).toThrow(/shadow the parent id/)
+  })
+
+  it('childPage keeps the bare parent param in auto mode (single-id family)', () => {
+    const ctx = makeCtx()
+    ctx.crud('p8jobs', { list: noopPage })
+    ctx.childPage('p8job', 'stats', { component: noopPage })
+
+    const page = findRoute('p8job-stats')
+    expect(page.path).toBe('p8jobs/:id/stats')
+    expect(page.meta.parent.param).toBe('id')
+  })
+})


### PR DESCRIPTION
Executes the accepted plan (+ amendment) on aiball #1201.

## Bug
`ctx.crud('botTasks', { list, show }, { parentRoute: 'job' })` generated `jobs/:id/tasks/:id` — the child `:id` shadows the parent in Vue Router, so `parentId` resolved to the **task** id. Breadcrumb, parentChain and FK filters were broken on every child show/edit page (also hit form-edit and set up `childPage()` for the same trap).

## Fix — `resolveParentParam`, per david's directives
Precedence: **per-call `parentParam`** > **kernel `routeParamResolver`** (global mapping service) > **`parentParamMode`**:

| Mode | Behavior |
|---|---|
| `auto` (default) | List-only families keep bare `:id` (**URLs unchanged** — the fallback david asked for); families with show/edit namespace the parent, principal (child) id stays `:id`: `jobs/:jobId/tasks/:id` |
| `always` | Namespaced everywhere |
| `bare` | Legacy naming + **explicit registration error** on collision (no more silent shadowing) |

`parentConfig.param` carries the resolved name → `useNavContext`, breadcrumb, parentChain, FK filter adapt with zero consumer change. Applied in `crud()` **and** `childPage()`.

## Back-compat
Only previously-**broken** families (two-id collision) change param names. Working list-only setups are byte-identical. → changeset **minor** (2.2.0).

## Tests
8 new (auto show / list-only / form-edit / per-call override / resolver + ctx shape / always / bare throw / childPage). Suite **1943 green**, `vue-tsc` clean, eslint clean on touched files.

aiball: #1201 (plan 5qccj6 + amendment a25at7 accepted). Unblocks skybot #1199 workaround removal.