### PR TITLE
refactor(pages): dedup page/composable copy-paste clusters (#1193)

### DIFF
--- a/.changeset/page-composable-dedup.md
+++ b/.changeset/page-composable-dedup.md
@@ -1,0 +1,5 @@
+---
+"@quazardous/qdadm": patch
+---
+
+Dedup the page/composable copy-paste clusters (#1193, KPI-6). New shared units: `CardShell` (conditional Card wrapper — ShowPage and FormPage no longer duplicate their entire content body per branch), `useActionRegistry<A, Ctx, R>` (the map + ordered add/remove/resolve skeleton behind the list/form/show action registries; per-page resolution stays local), `createOrchestratorToast()` (was verbatim ×3), `runFieldValidators` (required → type → custom pipeline shared by validateField/validate), `formatFetchError` (utils). `useListPage`/`useEntityItemPage` now use the canonical `useOrchestrator()` injection (same error message). Also: `editRouteSuffix` option is now honored in the create→edit redirect, small dead code removed. Pure refactor, zero behavior change.

--- a/packages/qdadm/src/components/edit/FormPage.vue
+++ b/packages/qdadm/src/components/edit/FormPage.vue
@@ -36,7 +36,8 @@ import { computed, type PropType } from 'vue'
 import PageHeader from '../layout/PageHeader.vue'
 import FormActions from './FormActions.vue'
 import UnsavedChangesDialog from '../dialogs/UnsavedChangesDialog.vue'
-import Card from 'primevue/card'
+import CardShell from '../layout/CardShell.vue'
+import { formatFetchError } from '../../utils/errors'
 import Button from 'primevue/button'
 import Message from 'primevue/message'
 import type { ResolvedAction, ResolvedFieldConfig } from '../../composables/useEntityItemFormPage'
@@ -119,11 +120,7 @@ const headerActions = computed<ResolvedAction[]>(() =>
 )
 
 // Get error message from fetchError
-const fetchErrorMessage = computed<string | null>(() => {
-  if (!props.fetchError) return null
-  if (typeof props.fetchError === 'string') return props.fetchError
-  return props.fetchError.message || props.fetchError.detail || 'Failed to load entity'
-})
+const fetchErrorMessage = computed<string | null>(() => formatFetchError(props.fetchError))
 
 // Guard dialog handlers
 function onGuardSaveAndLeave(): void {
@@ -205,29 +202,8 @@ function onGuardStay(): void {
         </ul>
       </Message>
 
-      <!-- Card wrapper or direct content -->
-      <Card v-if="cardWrapper">
-        <template #content>
-          <slot name="fields" />
-
-          <!-- Form Actions (in footer) -->
-          <template v-if="showFormActions">
-            <slot name="footer">
-              <FormActions
-                :isEdit="isEdit"
-                :saving="saving"
-                :dirty="dirty"
-                :showSaveAndClose="showSaveAndClose"
-                @save="emit('save')"
-                @saveAndClose="emit('saveAndClose')"
-                @cancel="emit('cancel')"
-              />
-            </slot>
-          </template>
-        </template>
-      </Card>
-
-      <template v-else>
+      <!-- Single content body; Card wrapper is conditional (#1193) -->
+      <CardShell :card="cardWrapper">
         <slot name="fields" />
 
         <!-- Form Actions (in footer) -->
@@ -244,7 +220,7 @@ function onGuardStay(): void {
             />
           </slot>
         </template>
-      </template>
+      </CardShell>
     </template>
 
     <!-- Unsaved Changes Dialog -->

--- a/packages/qdadm/src/components/layout/CardShell.vue
+++ b/packages/qdadm/src/components/layout/CardShell.vue
@@ -1,0 +1,26 @@
+<script setup lang="ts">
+/**
+ * CardShell — conditional Card wrapper (#1193).
+ *
+ * ShowPage and FormPage duplicated their entire content body twice (once
+ * inside <Card><template #content>, once bare). Wrapping the single body
+ * in this shell keeps the slots in the host component (no forwarding).
+ */
+import Card from 'primevue/card'
+
+defineProps<{
+  /** Wrap the default slot in a PrimeVue Card (#content). */
+  card?: boolean
+}>()
+</script>
+
+<template>
+  <Card v-if="card">
+    <template #content>
+      <slot />
+    </template>
+  </Card>
+  <template v-else>
+    <slot />
+  </template>
+</template>

--- a/packages/qdadm/src/components/show/ShowPage.vue
+++ b/packages/qdadm/src/components/show/ShowPage.vue
@@ -39,7 +39,8 @@
  */
 import { computed, type PropType } from 'vue'
 import PageHeader from '../layout/PageHeader.vue'
-import Card from 'primevue/card'
+import CardShell from '../layout/CardShell.vue'
+import { formatFetchError } from '../../utils/errors'
 import Button from 'primevue/button'
 import Message from 'primevue/message'
 import FieldGroups from '../item/FieldGroups.vue'
@@ -163,7 +164,7 @@ const useGroupLayout = computed(() => {
   return hasRealGroups && props.layout !== 'flat'
 })
 
-const emit = defineEmits<{
+defineEmits<{
   (e: 'edit'): void
   (e: 'delete'): void
   (e: 'back'): void
@@ -180,11 +181,11 @@ const footerActions = computed<ResolvedAction[]>(() =>
 )
 
 // Get error message from fetchError
-const fetchErrorMessage = computed<string | null>(() => {
-  if (!props.fetchError) return null
-  if (typeof props.fetchError === 'string') return props.fetchError
-  return props.fetchError.message || props.fetchError.detail || 'Failed to load entity'
-})
+const fetchErrorMessage = computed<string | null>(() => formatFetchError(props.fetchError))
+
+/** Value union accepted by ShowField — aliased so the template cast has no
+ * `|` (the eslint vue/no-deprecated-filter rule misreads it as a filter). */
+type ShowFieldValue = string | number | boolean | Date | Record<string, unknown> | unknown[]
 </script>
 
 <template>
@@ -232,70 +233,8 @@ const fetchErrorMessage = computed<string | null>(() => {
 
     <!-- Content -->
     <template v-else>
-      <!-- Card wrapper or direct content -->
-      <Card v-if="cardWrapper">
-        <template #content>
-          <!-- Grid layout with optional media zone -->
-          <div
-            class="show-content"
-            :class="{ 'show-content--with-media': slots.media }"
-            :style="slots.media ? { '--media-width': mediaWidth } : {}"
-          >
-            <!-- Media zone (optional) -->
-            <div v-if="slots.media" class="show-media">
-              <slot name="media" />
-            </div>
-
-            <!-- Fields/Groups zone -->
-            <div class="show-fields" :class="{ 'show-fields--horizontal': horizontalFields && !useGroupLayout }">
-              <!-- Group layout mode -->
-              <template v-if="useGroupLayout">
-                <slot name="groups">
-                  <FieldGroups
-                    :groups="groups"
-                    :data="data"
-                    :layout="layout"
-                    :child-layout="childLayout"
-                  >
-                    <template #field="{ field, value }">
-                      <ShowField
-                        :field="field"
-                        :value="value as string | number | boolean | Date | Record<string, unknown> | unknown[]"
-                        :horizontal="horizontalFields"
-                        :label-width="labelWidth"
-                      />
-                    </template>
-                  </FieldGroups>
-                </slot>
-              </template>
-              <!-- Flat fields mode (default) -->
-              <template v-else>
-                <slot name="fields" />
-              </template>
-            </div>
-          </div>
-
-          <!-- Footer Actions -->
-          <template v-if="showActions && footerActions.length > 0">
-            <slot name="footer">
-              <div class="show-actions">
-                <Button
-                  v-for="action in footerActions"
-                  :key="action.name"
-                  :label="action.label"
-                  :icon="action.icon"
-                  :severity="action.severity"
-                  :loading="action.isLoading"
-                  :disabled="action.isDisabled"
-                  @click="action.onClick"
-                />
-              </div>
-            </slot>
-          </template>
-        </template>
-      </Card>
-
-      <template v-else>
+      <!-- Single content body; Card wrapper is conditional (#1193) -->
+      <CardShell :card="cardWrapper">
         <!-- Grid layout with optional media zone -->
         <div
           class="show-content"
@@ -321,7 +260,7 @@ const fetchErrorMessage = computed<string | null>(() => {
                   <template #field="{ field, value }">
                     <ShowField
                       :field="field"
-                      :value="value as string | number | boolean | Date | Record<string, unknown> | unknown[]"
+                      :value="value as ShowFieldValue"
                       :horizontal="horizontalFields"
                       :label-width="labelWidth"
                     />
@@ -353,7 +292,7 @@ const fetchErrorMessage = computed<string | null>(() => {
             </div>
           </slot>
         </template>
-      </template>
+      </CardShell>
     </template>
   </div>
 </template>

--- a/packages/qdadm/src/composables/useActionRegistry.ts
+++ b/packages/qdadm/src/composables/useActionRegistry.ts
@@ -1,0 +1,82 @@
+/**
+ * Generic action registry (#1193) — the map + ordered add/remove/resolve
+ * skeleton was rebuilt in useListPage, useEntityItemFormPage and
+ * useEntityItemShowPage; only the resolution context differs, so the
+ * consumer supplies `resolve(action, ctx)` and calls `resolveAll(ctx)`.
+ */
+import { ref, type Ref } from 'vue'
+
+export interface UseActionRegistryOptions<A extends { name: string }, Ctx, R> {
+  /** Defaults merged under every added action (e.g. { severity: 'secondary' }). */
+  defaults?: Partial<A>
+  /**
+   * Resolve one action against the consumer's context. Return null to
+   * filter it out (visibility check lives here).
+   */
+  resolve: (action: A, ctx: Ctx) => R | null
+}
+
+export interface UseActionRegistryReturn<A extends { name: string }, Ctx, R> {
+  /** Raw registered actions, insertion-ordered (exposed for advanced consumers). */
+  actionsMap: Ref<Map<string, A>>
+  /** Registration order — kept explicit so external entries (e.g. lazy actions) can share it. */
+  order: Ref<string[]>
+  add(action: A): void
+  remove(name: string): void
+  has(name: string): boolean
+  /** Drop every registered action (order included). */
+  clear(): void
+  /** Resolve every registered action in order, dropping nulls. */
+  resolveAll(ctx: Ctx): R[]
+  /** Resolve a single registered action by name (null if absent or filtered). */
+  resolveOne(name: string, ctx: Ctx): R | null
+}
+
+export function useActionRegistry<A extends { name: string }, Ctx = void, R = A>(
+  options: UseActionRegistryOptions<A, Ctx, R>
+): UseActionRegistryReturn<A, Ctx, R> {
+  const { defaults, resolve } = options
+  const actionsMap = ref(new Map()) as Ref<Map<string, A>>
+  const order = ref<string[]>([])
+
+  function add(action: A): void {
+    actionsMap.value.set(action.name, { ...defaults, ...action })
+    if (!order.value.includes(action.name)) {
+      order.value.push(action.name)
+    }
+  }
+
+  function remove(name: string): void {
+    actionsMap.value.delete(name)
+    const idx = order.value.indexOf(name)
+    if (idx !== -1) order.value.splice(idx, 1)
+  }
+
+  function has(name: string): boolean {
+    return actionsMap.value.has(name)
+  }
+
+  function clear(): void {
+    actionsMap.value.clear()
+    order.value = []
+  }
+
+  function resolveAll(ctx: Ctx): R[] {
+    const resolved: R[] = []
+    for (const name of order.value) {
+      const action = actionsMap.value.get(name)
+      if (!action) continue
+      const r = resolve(action, ctx)
+      if (r !== null) resolved.push(r)
+    }
+    return resolved
+  }
+
+  function resolveOne(name: string, ctx: Ctx): R | null {
+    const action = actionsMap.value.get(name)
+    if (!action) return null
+    return resolve(action, ctx)
+  }
+
+  return { actionsMap, order, add, remove, has, clear, resolveAll, resolveOne }
+}

--- a/packages/qdadm/src/composables/useBareForm.ts
+++ b/packages/qdadm/src/composables/useBareForm.ts
@@ -36,6 +36,7 @@ import { useUnsavedChangesGuard, type GuardDialogState } from './useUnsavedChang
 import { useBreadcrumb, type BreadcrumbDisplayItem } from './useBreadcrumb'
 import { registerGuardDialog, unregisterGuardDialog } from './useGuardStore'
 import type { EntityManagerLike, OrchestratorLike } from '../entity/EntityManager.interface'
+import { createOrchestratorToast } from './useOrchestratorToast'
 
 // #1191 — shared minimal structural views (was: local redeclarations)
 type EntityManager = EntityManagerLike
@@ -169,12 +170,8 @@ export function useBareForm(options: UseBareFormOptions): UseBareFormReturn {
   const route = useRoute()
   const orchestrator = inject<Orchestrator | null>('qdadmOrchestrator', null)
 
-  // Toast helper - wraps orchestrator.toast for legacy compatibility
-  const toast: ToastHelper = {
-    add({ severity, summary, detail, emitter }) {
-      orchestrator?.toast[severity]?.(summary, detail, emitter)
-    },
-  }
+  // Toast helper (#1193 — shared facade)
+  const toast: ToastHelper = createOrchestratorToast(orchestrator)
 
   // Common state
   const loading = ref(false)

--- a/packages/qdadm/src/composables/useEntityItemFormPage.ts
+++ b/packages/qdadm/src/composables/useEntityItemFormPage.ts
@@ -569,34 +569,41 @@ export function useEntityItemFormPage<T extends Record<string, unknown> = Record
 
   // ============ VALIDATION ============
 
-  function validateField(name: string): string | null {
-    const fieldConfig = fieldsMap.value.get(name)
-    if (!fieldConfig) return null
-
-    const value = data.value[name]
-
+  /**
+   * Shared validator pipeline (#1193): required → type validator → custom
+   * validate. Pure — returns the error message or null; callers own the
+   * errors ref bookkeeping.
+   */
+  function runFieldValidators(fieldConfig: ResolvedFieldConfig, value: unknown): string | null {
     if (fieldConfig.required && isEmpty(value)) {
-      const error = `${fieldConfig.label} is required`
-      errors.value = { ...errors.value, [name]: error }
-      return error
+      return `${fieldConfig.label} is required`
     }
 
     const typeValidator = TYPE_VALIDATORS[fieldConfig.schemaType]
     if (typeValidator) {
       const result = typeValidator(value)
-      if (result !== true) {
-        errors.value = { ...errors.value, [name]: result as string }
-        return result as string
-      }
+      if (result !== true) return result as string
     }
 
     if (fieldConfig.validate && typeof fieldConfig.validate === 'function') {
       const result = fieldConfig.validate(value, data.value)
       if (result !== true && result !== undefined && result !== null) {
-        const error = typeof result === 'string' ? result : `${fieldConfig.label} is invalid`
-        errors.value = { ...errors.value, [name]: error }
-        return error
+        return typeof result === 'string' ? result : `${fieldConfig.label} is invalid`
       }
+    }
+
+    return null
+  }
+
+  function validateField(name: string): string | null {
+    const fieldConfig = fieldsMap.value.get(name)
+    if (!fieldConfig) return null
+
+    const error = runFieldValidators(fieldConfig, data.value[name])
+
+    if (error) {
+      errors.value = { ...errors.value, [name]: error }
+      return error
     }
 
     if (errors.value[name]) {
@@ -615,29 +622,8 @@ export function useEntityItemFormPage<T extends Record<string, unknown> = Record
       const fieldConfig = fieldsMap.value.get(fieldName)
       if (!fieldConfig) continue
 
-      const value = data.value[fieldName]
-
-      if (fieldConfig.required && isEmpty(value)) {
-        newErrors[fieldName] = `${fieldConfig.label} is required`
-        continue
-      }
-
-      const typeValidator = TYPE_VALIDATORS[fieldConfig.schemaType]
-      if (typeValidator) {
-        const result = typeValidator(value)
-        if (result !== true) {
-          newErrors[fieldName] = result as string
-          continue
-        }
-      }
-
-      if (fieldConfig.validate && typeof fieldConfig.validate === 'function') {
-        const result = fieldConfig.validate(value, data.value)
-        if (result !== true && result !== undefined && result !== null) {
-          newErrors[fieldName] =
-            typeof result === 'string' ? result : `${fieldConfig.label} is invalid`
-        }
-      }
+      const error = runFieldValidators(fieldConfig, data.value[fieldName])
+      if (error) newErrors[fieldName] = error
     }
 
     errors.value = newErrors

--- a/packages/qdadm/src/composables/useEntityItemFormPage.ts
+++ b/packages/qdadm/src/composables/useEntityItemFormPage.ts
@@ -51,6 +51,7 @@ import type {
   PageTitleParts,
 } from './useEntityItemFormPage.types'
 import { createOrchestratorToast } from './useOrchestratorToast'
+import { useActionRegistry } from './useActionRegistry'
 import { TYPE_MAPPINGS, TYPE_VALIDATORS, snakeCaseToTitle, isEmpty } from './useEntityItemFormPage.types'
 
 // Re-export public types
@@ -667,29 +668,30 @@ export function useEntityItemFormPage<T extends Record<string, unknown> = Record
 
   // ============ ACTIONS ============
 
-  const actionsMap = ref<Map<string, ActionConfig>>(new Map())
-
-  function addAction(name: string, actionConfig: Omit<ActionConfig, 'name'>): void {
-    actionsMap.value.set(name, { name, ...actionConfig })
-  }
-
-  function removeAction(name: string): void {
-    actionsMap.value.delete(name)
-  }
-
-  function getActions(): ResolvedAction[] {
-    const actions: ResolvedAction[] = []
-    for (const [, action] of actionsMap.value) {
-      if (action.visible && !action.visible({ isEdit: isEdit.value, dirty: dirty.value })) continue
-      actions.push({
+  // #1193 — shared registry skeleton; form-state resolution stays here
+  const actionRegistry = useActionRegistry<ActionConfig, void, ResolvedAction>({
+    resolve: (action) => {
+      if (action.visible && !action.visible({ isEdit: isEdit.value, dirty: dirty.value })) return null
+      return {
         ...action,
         isLoading: action.loading ? action.loading() : false,
         isDisabled: action.disabled
           ? action.disabled({ dirty: dirty.value, saving: saving.value })
           : false,
-      })
-    }
-    return actions
+      }
+    },
+  })
+
+  function addAction(name: string, actionConfig: Omit<ActionConfig, 'name'>): void {
+    actionRegistry.add({ name, ...actionConfig } as ActionConfig)
+  }
+
+  function removeAction(name: string): void {
+    actionRegistry.remove(name)
+  }
+
+  function getActions(): ResolvedAction[] {
+    return actionRegistry.resolveAll(undefined)
   }
 
   const actions = computed(() => getActions())

--- a/packages/qdadm/src/composables/useEntityItemFormPage.ts
+++ b/packages/qdadm/src/composables/useEntityItemFormPage.ts
@@ -50,6 +50,7 @@ import type {
   ErrorSummaryItem,
   PageTitleParts,
 } from './useEntityItemFormPage.types'
+import { createOrchestratorToast } from './useOrchestratorToast'
 import { TYPE_MAPPINGS, TYPE_VALIDATORS, snakeCaseToTitle, isEmpty } from './useEntityItemFormPage.types'
 
 // Re-export public types
@@ -100,7 +101,7 @@ export function useEntityItemFormPage<T extends Record<string, unknown> = Record
     // Mode detection
     getId = null,
     createRouteSuffix = 'create',
-    editRouteSuffix: _editRouteSuffix = 'edit', // eslint-disable-line @typescript-eslint/no-unused-vars
+    editRouteSuffix = 'edit',
     // Form options
     loadOnMount = true,
     enableGuard = true,
@@ -143,12 +144,8 @@ export function useEntityItemFormPage<T extends Record<string, unknown> = Record
     hydrator,
   } = itemPage
 
-  // Toast helper - wraps orchestrator.toast for legacy compatibility
-  const toast: ToastHelper = {
-    add({ severity, summary, detail, emitter }) {
-      ;(orchestrator as Orchestrator)?.toast?.[severity]?.(summary, detail, emitter)
-    },
-  }
+  // Toast helper (#1193 — shared facade)
+  const toast: ToastHelper = createOrchestratorToast(orchestrator as Orchestrator | null)
 
   // Read config from manager with option overrides
   const entityName = config.entityName ?? manager.label
@@ -331,7 +328,7 @@ export function useEntityItemFormPage<T extends Record<string, unknown> = Record
         const createdId = (responseData as Record<string, unknown>)?.[manager.idField]
         if (createdId) {
           const currentRouteName = (route.name as string) || ''
-          const editRouteName = currentRouteName.replace(/(-create|-new)$/, '-edit')
+          const editRouteName = currentRouteName.replace(/(-create|-new)$/, `-${editRouteSuffix}`)
           router.push({
             name: editRouteName,
             params: { ...route.params, [manager.idField]: String(createdId) },
@@ -505,7 +502,7 @@ export function useEntityItemFormPage<T extends Record<string, unknown> = Record
   })
 
   // Expose refs for validation (which needs direct access)
-  const { fieldsMap, fieldOrder, excludedFields, fields, groups } = fieldManager
+  const { fieldsMap, fieldOrder, fields, groups } = fieldManager
 
   /**
    * Generate fields from manager schema

--- a/packages/qdadm/src/composables/useEntityItemPage.ts
+++ b/packages/qdadm/src/composables/useEntityItemPage.ts
@@ -12,11 +12,12 @@
  * - Show pages (read-only detail pages)
  * - useEntityItemFormPage (create/edit forms)
  */
-import { ref, computed, onMounted, inject, provide, type Ref, type ComputedRef } from 'vue'
+import { ref, computed, onMounted, provide, type Ref, type ComputedRef } from 'vue'
 import { useRoute } from 'vue-router'
 import { useStackHydrator, type StackHydratorReturn } from '../chain/useStackHydrator'
 import type { EntityManagerCrud } from '../entity/EntityManager.interface'
 import type { OrchestratorLike } from '../entity/EntityManager.interface'
+import { useOrchestrator } from '../orchestrator/useOrchestrator.js'
 
 /**
  * Parent configuration from route.meta.parent
@@ -142,7 +143,8 @@ export function useEntityItemPage<T = unknown>(config: UseEntityItemPageOptions<
   const route = useRoute()
 
   // Get EntityManager via orchestrator
-  const orchestrator = inject<Orchestrator | null>('qdadmOrchestrator')
+  // #1193 — canonical injection (single error-message source), erased to the CRUD-tier view
+  const orchestrator = useOrchestrator().orchestrator as unknown as Orchestrator
   if (!orchestrator) {
     throw new Error(
       '[qdadm] Orchestrator not provided.\n' +
@@ -232,7 +234,6 @@ export function useEntityItemPage<T = unknown>(config: UseEntityItemPageOptions<
       // Calculate total depth to set correct breadcrumb levels
       // If chain is: grandparent -> parent -> current
       // grandparent = level 1, parent = level 2, current = level 3
-      // const totalDepth = getChainDepth()
 
       // Load chain from immediate parent up to root
       let currentConfig: ParentConfig | undefined = parentConfig.value

--- a/packages/qdadm/src/composables/useEntityItemShowPage.ts
+++ b/packages/qdadm/src/composables/useEntityItemShowPage.ts
@@ -55,6 +55,7 @@ import {
   type ShowResolvedFieldConfig,
 } from './createShowFieldResolver'
 import type { OrchestratorLike } from '../entity/EntityManager.interface'
+import { useActionRegistry } from './useActionRegistry'
 
 // #1191 — shared structural view (manager tier from useEntityItemPage)
 type Orchestrator = OrchestratorLike<EntityManager>
@@ -344,17 +345,27 @@ export function useEntityItemShowPage<T = unknown>(
 
   // ============ ACTION MANAGEMENT ============
 
-  const actionsMap = ref<Map<string, ActionConfig>>(new Map())
-  const actionOrder = ref<string[]>([])
-
   const canEdit = computed(() => manager.canUpdate?.(data.value) ?? true)
   const canDelete = computed(() => manager.canDelete?.(data.value) ?? true)
 
+  // #1193 — shared registry skeleton; the order list is shared with lazy
+  // actions so declaration order survives the regular/lazy interleave.
+  type ShowActionCtx = { canEdit: boolean; canDelete: boolean; loading: boolean }
+  const actionRegistry = useActionRegistry<ActionConfig, ShowActionCtx, ResolvedAction>({
+    resolve: (action, ctx) => {
+      if (action.visible && !action.visible(ctx)) return null
+      return {
+        ...action,
+        isLoading: action.loading ? action.loading() : false,
+        isDisabled: action.disabled ? action.disabled(ctx) : false,
+      }
+    },
+  })
+  const actionsMap = actionRegistry.actionsMap
+  const actionOrder = actionRegistry.order
+
   function addAction(action: ActionConfig): UseEntityItemShowPageReturn<T> {
-    actionsMap.value.set(action.name, action)
-    if (!actionOrder.value.includes(action.name)) {
-      actionOrder.value.push(action.name)
-    }
+    actionRegistry.add(action)
     return returnValue
   }
 
@@ -445,20 +456,16 @@ export function useEntityItemShowPage<T = unknown>(
         return null
       })
       .filter((entry): entry is NonNullable<typeof entry> => entry !== null)
-      .filter((entry) => {
-        if (entry.type === 'regular') return !entry.action.visible || entry.action.visible(ctx)
-        const state = resolved.get(entry.action.name)
-        return state?.visible === true
-      })
       .map((entry) => {
-        const a = entry.action
-        if (entry.type === 'lazy') {
-          const state = resolved.get(a.name)
-          return { ...a, isLoading: a.loading ? a.loading() : false, isDisabled: state?.disabled ?? false }
+        if (entry.type === 'regular') {
+          return actionRegistry.resolveOne(entry.action.name, ctx)
         }
-        const regular = a as ActionConfig
-        return { ...regular, isLoading: regular.loading ? regular.loading() : false, isDisabled: regular.disabled ? regular.disabled(ctx) : false }
+        const state = resolved.get(entry.action.name)
+        if (state?.visible !== true) return null
+        const a = entry.action
+        return { ...a, isLoading: a.loading ? a.loading() : false, isDisabled: state?.disabled ?? false }
       })
+      .filter((a): a is ResolvedAction => a !== null)
   })
 
   // ============ PAGE TITLE ============

--- a/packages/qdadm/src/composables/useListPage.ts
+++ b/packages/qdadm/src/composables/useListPage.ts
@@ -95,6 +95,8 @@ import {
   setSessionFilters,
   snakeToTitle,
 } from './useListPage.utils'
+import { useOrchestrator } from '../orchestrator/useOrchestrator.js'
+import { createOrchestratorToast } from './useOrchestratorToast'
 
 // Re-export PAGE_SIZE_OPTIONS so existing consumers (qdadm/index.ts,
 // composables/index.ts) keep their import path.
@@ -134,15 +136,10 @@ export function useListPage<T = unknown>(config: UseListPageOptions<T>): UseList
   // i18n integration — column headers resolve via entities.{entity}.fields.{field}
   const { i18n: kernelI18n, locale: i18nLocale } = useI18n()
 
-  // Get EntityManager via orchestrator
-  const orchestrator = inject<Orchestrator | null>('qdadmOrchestrator')
-
-  // Toast helper - wraps orchestrator.toast for legacy compatibility
-  const toast: ToastHelper = {
-    add({ severity, summary, detail, emitter }) {
-      orchestrator?.toast[severity]?.(summary, detail, emitter)
-    },
-  }
+  // Get EntityManager via orchestrator (#1193 — canonical injection: one
+  // error-message source; erased to this file's Read-tier view)
+  const orchestrator = useOrchestrator().orchestrator as unknown as Orchestrator
+  const toast: ToastHelper = createOrchestratorToast(orchestrator)
 
   if (!orchestrator) {
     throw new Error(

--- a/packages/qdadm/src/composables/useListPage.ts
+++ b/packages/qdadm/src/composables/useListPage.ts
@@ -95,6 +95,7 @@ import {
   setSessionFilters,
   snakeToTitle,
 } from './useListPage.utils'
+import { useActionRegistry } from './useActionRegistry'
 import { useOrchestrator } from '../orchestrator/useOrchestrator.js'
 import { createOrchestratorToast } from './useOrchestratorToast'
 
@@ -832,38 +833,37 @@ export function useListPage<T = unknown>(config: UseListPageOptions<T>): UseList
   }
 
   // ============ ACTIONS ============
-  const actionsMap = ref<Map<string, ActionConfig>>(new Map())
-
-  function addAction(name: string, actionConfig: Omit<ActionConfig, 'name'>): void {
-    actionsMap.value.set(name, {
-      name,
-      severity: 'secondary',
-      ...actionConfig,
-    } as ActionConfig)
-  }
-
-  function removeAction(name: string): void {
-    actionsMap.value.delete(name)
-  }
-
   function resolveValue<T>(value: T | ((row: unknown) => T), row: unknown): T {
     return typeof value === 'function' ? (value as (row: unknown) => T)(row) : value
   }
 
-  function getActions(row: unknown): ResolvedAction[] {
-    const actions: ResolvedAction[] = []
-    for (const [, action] of actionsMap.value) {
-      if (action.visible && !action.visible(row)) continue
-      actions.push({
+  // #1193 — shared registry skeleton; row-aware resolution stays here
+  const actionRegistry = useActionRegistry<ActionConfig, unknown, ResolvedAction>({
+    defaults: { severity: 'secondary' },
+    resolve: (action, row) => {
+      if (action.visible && !action.visible(row)) return null
+      return {
         name: action.name,
         icon: action.icon ? resolveValue(action.icon, row) : undefined,
         tooltip: action.tooltip ? resolveValue(action.tooltip, row) : undefined,
         severity: resolveValue(action.severity || 'secondary', row),
         isDisabled: action.disabled ? action.disabled(row) : false,
         handler: () => action.onClick(row),
-      })
-    }
-    return actions
+      }
+    },
+  })
+  const actionsMap = actionRegistry.actionsMap
+
+  function addAction(name: string, actionConfig: Omit<ActionConfig, 'name'>): void {
+    actionRegistry.add({ name, ...actionConfig } as ActionConfig)
+  }
+
+  function removeAction(name: string): void {
+    actionRegistry.remove(name)
+  }
+
+  function getActions(row: unknown): ResolvedAction[] {
+    return actionRegistry.resolveAll(row)
   }
 
   // ============ SEARCH ============
@@ -1273,9 +1273,10 @@ export function useListPage<T = unknown>(config: UseListPageOptions<T>): UseList
     }
 
     if (alteredConfig.actions) {
-      actionsMap.value.clear()
+      // Route through the registry so the order list stays in sync (#1193)
+      actionRegistry.clear()
       for (const action of alteredConfig.actions) {
-        actionsMap.value.set(action.name, action)
+        actionRegistry.add(action)
       }
     }
 

--- a/packages/qdadm/src/composables/useOrchestratorToast.ts
+++ b/packages/qdadm/src/composables/useOrchestratorToast.ts
@@ -1,0 +1,26 @@
+/**
+ * Orchestrator toast facade (#1193) — was copy-pasted verbatim in
+ * useListPage, useEntityItemFormPage and useBareForm.
+ */
+import type { OrchestratorLike } from '../entity/EntityManager.interface'
+
+/** Legacy-compatible toast surface used across the page composables. */
+export interface ToastHelper {
+  add(options: {
+    severity: 'success' | 'error' | 'warn' | 'info'
+    summary: string
+    detail?: string
+    emitter?: unknown
+  }): void
+}
+
+/** Build the facade over any orchestrator-shaped object (null-tolerant). */
+export function createOrchestratorToast(
+  orchestrator: Pick<OrchestratorLike, 'toast'> | null | undefined
+): ToastHelper {
+  return {
+    add({ severity, summary, detail, emitter }) {
+      orchestrator?.toast?.[severity]?.(summary, detail, emitter)
+    },
+  }
+}

--- a/packages/qdadm/src/utils/errors.ts
+++ b/packages/qdadm/src/utils/errors.ts
@@ -1,0 +1,22 @@
+/**
+ * Error formatting helpers (#1193).
+ */
+
+/** Fetch-error shape accepted by the page components. */
+export interface FetchErrorLike {
+  message?: string
+  detail?: string
+}
+
+/**
+ * Normalize a fetch error (string or axios-ish object) to a display
+ * message — was duplicated byte-identically in ShowPage and FormPage.
+ */
+export function formatFetchError(
+  error: string | FetchErrorLike | null | undefined,
+  fallback = 'Failed to load entity'
+): string | null {
+  if (!error) return null
+  if (typeof error === 'string') return error
+  return error.message || error.detail || fallback
+}

--- a/packages/qdadm/src/utils/index.ts
+++ b/packages/qdadm/src/utils/index.ts
@@ -18,6 +18,9 @@ export {
   formatPercent,
 } from './formatters'
 
+// Error formatting
+export { formatFetchError, type FetchErrorLike } from './errors'
+
 // Transformers
 export {
   toKeyValueArray,


### PR DESCRIPTION
Executes aiball #1193 ([KPI-6] of the #1187 umbrella). Pure refactor, zero behavior change.

## New shared units
| Unit | Replaces |
|---|---|
| `CardShell` (private component) | ShowPage + FormPage duplicating their **entire content body** per Card/no-Card branch (~60 lines ×2 each) — single body, conditional wrapper, zero slot forwarding |
| `useActionRegistry<A, Ctx, R>` | The map + ordered add/remove/resolve skeleton rebuilt ×3 (list/form/show); per-page resolution stays local (row-fns vs form-state vs show ctx); show's lazy-action interleave keeps working through the shared `order` list |
| `createOrchestratorToast()` | Toast facade verbatim ×3 |
| `runFieldValidators()` | required → type → custom pipeline duplicated in `validateField`/`validate` |
| `formatFetchError()` (utils) | byte-identical computed ×2 |

Plus: canonical `useOrchestrator()` injection in useListPage/useEntityItemPage (the copy-pasted error message came from there — identical behavior, one source), `editRouteSuffix` option now honored, dead leftovers removed, `no-deprecated-filter` false positive fixed (union-type cast aliased).

## Deliberate non-extractions (documented in commit)
- Loading/error template blocks: public-slot plumbing — extraction forces slot forwarding costlier than the ~15-line duplication.
- Header/footer Button loops in ShowPage: 2 similar loops left in one file after the CardShell dedup removed the third; marginal.

## Safety
- `list:alter` hook path routed through the registry (a test caught the order-list desync — fixed with `registry.clear()`).
- Suite **1972 green** (incl. 97 formPage + 57 listPage behavior locks), `vue-tsc` clean, 0 eslint errors on touched files, demo builds.
- Changeset **patch**.

aiball: #1193.