### PR TITLE
refactor(lists): extract filter + alter-hook subsystems from useListPage (#1195)

### DIFF
--- a/.changeset/split-uselistpage.md
+++ b/.changeset/split-uselistpage.md
@@ -1,0 +1,5 @@
+---
+"@quazardous/qdadm": patch
+---
+
+Split `useListPage.ts` (#1195, KPI-8): the two self-contained subsystems are extracted into composables it composes back in — `useListFilters` (filter state, the three option-source modes optionsEntity/optionsEndpoint/optionsFromCache, session persistence, URL sync, registry auto-load) and `useListAlterHooks` (`list:alter`/`filter:alter` wiring). Pure mechanical extraction: the public surface is unchanged and the existing useListPage tests pass untouched; the file drops from 1557 to ~1200 lines and both subsystems now have focused unit tests. `QueryOrchestratorLike` is now exported from FilterQuery.

--- a/packages/qdadm/src/composables/useListPage.alterHooks.ts
+++ b/packages/qdadm/src/composables/useListPage.alterHooks.ts
@@ -1,0 +1,153 @@
+/**
+ * useListAlterHooks — the list:alter / filter:alter hook wiring of
+ * useListPage (#1195, KPI-8).
+ *
+ * Mechanical extraction: snapshots the list config, runs the global and
+ * entity-scoped alter hooks, and applies the altered config back onto the
+ * live state (columns, filters, actions via the shared registry, header
+ * actions). useListPage composes it back in; behavior is unchanged.
+ */
+import type { Ref } from 'vue'
+import type {
+  ActionConfig,
+  ColumnConfig,
+  FilterConfig,
+  HeaderActionConfig,
+  ResolvedAction,
+} from './useListPage.types'
+import type { UseActionRegistryReturn } from './useActionRegistry'
+
+/** Minimal HookRegistry view (what the alter flow actually uses). */
+export interface AlterHooksLike {
+  alter: (name: string, value: unknown) => Promise<unknown>
+  hasHook: (name: string) => boolean
+}
+
+/** Dependencies injected by useListPage. */
+export interface UseListAlterHooksDeps {
+  hooks: AlterHooksLike | null | undefined
+  entity: string
+  manager: unknown
+  columnsMap: Ref<Map<string, ColumnConfig>>
+  filtersMap: Ref<Map<string, FilterConfig>>
+  filterValues: Ref<Record<string, unknown>>
+  headerActionsMap: Ref<Map<string, HeaderActionConfig>>
+  actionRegistry: UseActionRegistryReturn<ActionConfig, unknown, ResolvedAction>
+}
+
+export interface UseListAlterHooksReturn {
+  invokeListAlterHook: () => Promise<void>
+  invokeFilterAlterHook: () => Promise<void>
+}
+
+export function useListAlterHooks(deps: UseListAlterHooksDeps): UseListAlterHooksReturn {
+  const {
+    hooks,
+    entity,
+    manager,
+    columnsMap,
+    filtersMap,
+    filterValues,
+    headerActionsMap,
+    actionRegistry,
+  } = deps
+  const actionsMap = actionRegistry.actionsMap
+
+  async function invokeListAlterHook(): Promise<void> {
+    if (!hooks) return
+
+    const configSnapshot = {
+      entity,
+      columns: Array.from(columnsMap.value.values()),
+      filters: Array.from(filtersMap.value.values()),
+      actions: Array.from(actionsMap.value.values()),
+      headerActions: Array.from(headerActionsMap.value.values()),
+    }
+
+    // Include entity context in the snapshot for hooks
+    const configWithContext = { ...configSnapshot, entity, manager }
+
+    let alteredConfig = await hooks.alter('list:alter', configWithContext)
+
+    const entityHookName = `${entity}:list:alter`
+    if (hooks.hasHook(entityHookName)) {
+      alteredConfig = await hooks.alter(entityHookName, alteredConfig)
+    }
+
+    applyAlteredConfig(
+      alteredConfig as {
+        columns?: ColumnConfig[]
+        filters?: FilterConfig[]
+        actions?: ActionConfig[]
+        headerActions?: HeaderActionConfig[]
+      }
+    )
+  }
+
+  async function invokeFilterAlterHook(): Promise<void> {
+    if (!hooks) return
+
+    const filterSnapshot = {
+      entity,
+      filters: Array.from(filtersMap.value.values()),
+    }
+
+    let alteredFilters = (await hooks.alter('filter:alter', filterSnapshot)) as typeof filterSnapshot
+
+    const entityHookName = `${entity}:filter:alter`
+    if (hooks.hasHook(entityHookName)) {
+      alteredFilters = (await hooks.alter(entityHookName, alteredFilters)) as typeof filterSnapshot
+    }
+
+    if (alteredFilters.filters) {
+      filtersMap.value.clear()
+      for (const filter of alteredFilters.filters) {
+        filtersMap.value.set(filter.name, filter)
+        if (filterValues.value[filter.name] === undefined) {
+          filterValues.value[filter.name] = filter.default ?? null
+        }
+      }
+    }
+  }
+
+  function applyAlteredConfig(alteredConfig: {
+    columns?: ColumnConfig[]
+    filters?: FilterConfig[]
+    actions?: ActionConfig[]
+    headerActions?: HeaderActionConfig[]
+  }): void {
+    if (alteredConfig.columns) {
+      columnsMap.value.clear()
+      for (const col of alteredConfig.columns) {
+        columnsMap.value.set(col.field, col)
+      }
+    }
+
+    if (alteredConfig.filters) {
+      filtersMap.value.clear()
+      for (const filter of alteredConfig.filters) {
+        filtersMap.value.set(filter.name, filter)
+        if (filterValues.value[filter.name] === undefined) {
+          filterValues.value[filter.name] = filter.default ?? null
+        }
+      }
+    }
+
+    if (alteredConfig.actions) {
+      // Route through the registry so the order list stays in sync (#1193)
+      actionRegistry.clear()
+      for (const action of alteredConfig.actions) {
+        actionRegistry.add(action)
+      }
+    }
+
+    if (alteredConfig.headerActions) {
+      headerActionsMap.value.clear()
+      for (const action of alteredConfig.headerActions) {
+        headerActionsMap.value.set(action.name, action)
+      }
+    }
+  }
+
+  return { invokeListAlterHook, invokeFilterAlterHook }
+}

--- a/packages/qdadm/src/composables/useListPage.filters.ts
+++ b/packages/qdadm/src/composables/useListPage.filters.ts
@@ -1,0 +1,421 @@
+/**
+ * useListFilters — the filter subsystem of useListPage (#1195, KPI-8).
+ *
+ * Mechanical extraction: owns the filter state (filtersMap/filterValues),
+ * the three option-source modes (optionsEntity / optionsEndpoint /
+ * optionsFromCache), session persistence, URL sync and registry auto-load.
+ * useListPage composes it back in; behavior is unchanged.
+ */
+import { ref, computed, type Ref, type ComputedRef } from 'vue'
+import type { RouteLocationNormalizedLoaded, Router } from 'vue-router'
+import { FilterQuery, type QueryOrchestratorLike } from '../query/FilterQuery'
+import type { FilterConfig, SearchConfig } from './useListPage.types'
+import {
+  SMART_FILTER_THRESHOLD,
+  clearSessionFilters,
+  setSessionFilters,
+  snakeToTitle,
+} from './useListPage.utils'
+
+/** Dependencies injected by useListPage. */
+export interface UseListFiltersDeps {
+  /** Entity name used for the registry lookup. */
+  entityName: string
+  /** EntityManager (needs .request for optionsEndpoint mode). */
+  manager: { request: (method: string, endpoint: string) => Promise<unknown> }
+  /** Orchestrator, forwarded to FilterQuery for optionsEntity mode. */
+  orchestrator: QueryOrchestratorLike | null | undefined
+  /** Loaded list items (source for optionsFromCache mode). */
+  items: Ref<unknown[]>
+  /** Current page ref — filter changes reset it to 1. */
+  page: Ref<number>
+  /** Search query ref (shared with the search subsystem). */
+  searchQuery: Ref<string>
+  route: RouteLocationNormalizedLoaded
+  router: Router
+  /** Session-restored filter values (already stripped of _search). */
+  savedFilters: Record<string, unknown> | null
+  persistFilters: boolean
+  syncUrlParams: boolean
+  autoLoadFilters: boolean
+  filterSessionKey: string
+  /** Entity filters registry (injected by the consuming app). */
+  entityFilters: Record<string, { search?: SearchConfig; filters?: FilterConfig[] }>
+  /** Thunks — resolved lazily, the targets are declared later in useListPage. */
+  loadItems: () => void
+  setSearch: (searchCfg: Partial<SearchConfig>) => void
+  invokeFilterAlterHook: () => Promise<void>
+}
+
+export interface UseListFiltersReturn {
+  filtersMap: Ref<Map<string, FilterConfig>>
+  filterValues: Ref<Record<string, unknown>>
+  filters: ComputedRef<FilterConfig[]>
+  hasActiveFilters: ComputedRef<boolean>
+  addFilter: (name: string, filterConfig: Omit<FilterConfig, 'name'>) => void
+  removeFilter: (name: string) => void
+  setFilterValue: (name: string, value: unknown) => void
+  updateFilters: (newValues: Record<string, unknown>) => void
+  onFiltersChanged: () => void
+  clearFilters: () => void
+  isFilterAtDefault: (name: string) => boolean
+  initFromRegistry: () => void
+  loadFilterOptions: () => Promise<void>
+  updateCacheBasedFilters: () => Promise<void>
+  restoreFilters: () => void
+}
+
+export function useListFilters(deps: UseListFiltersDeps): UseListFiltersReturn {
+  const {
+    entityName,
+    manager,
+    orchestrator,
+    items,
+    page,
+    searchQuery,
+    route,
+    router,
+    savedFilters,
+    persistFilters,
+    syncUrlParams,
+    autoLoadFilters,
+    filterSessionKey,
+    entityFilters,
+    loadItems,
+    setSearch,
+    invokeFilterAlterHook,
+  } = deps
+
+  const filtersMap = ref<Map<string, FilterConfig>>(new Map())
+  const filterValues = ref<Record<string, unknown>>(savedFilters || {})
+
+  function addFilter(name: string, filterConfig: Omit<FilterConfig, 'name'>): void {
+    filtersMap.value.set(name, {
+      name,
+      type: 'select',
+      placeholder: name,
+      ...filterConfig,
+    })
+    if (filterValues.value[name] === undefined) {
+      filterValues.value[name] = filterConfig.default ?? null
+    }
+  }
+
+  function removeFilter(name: string): void {
+    filtersMap.value.delete(name)
+    delete filterValues.value[name]
+  }
+
+  function setFilterValue(name: string, value: unknown): void {
+    filterValues.value = { ...filterValues.value, [name]: value }
+  }
+
+  function updateFilters(newValues: Record<string, unknown>): void {
+    filterValues.value = { ...filterValues.value, ...newValues }
+    onFiltersChanged()
+  }
+
+  function onFiltersChanged(): void {
+    page.value = 1
+    loadItems()
+    if (persistFilters) {
+      const toPersist: Record<string, unknown> = {}
+      for (const [name, value] of Object.entries(filterValues.value)) {
+        const filterDef = filtersMap.value.get(name)
+        if (
+          filterDef?.persist !== false &&
+          value !== null &&
+          value !== undefined &&
+          value !== ''
+        ) {
+          toPersist[name] = value
+        }
+      }
+      if (searchQuery.value) {
+        toPersist._search = searchQuery.value
+      }
+      setSessionFilters(filterSessionKey, toPersist)
+    }
+    if (syncUrlParams) {
+      const query = { ...route.query } as Record<string, string>
+      for (const [name, value] of Object.entries(filterValues.value)) {
+        if (value !== null && value !== undefined && value !== '') {
+          query[name] = String(value)
+        } else {
+          delete query[name]
+        }
+      }
+      if (searchQuery.value) {
+        query.search = searchQuery.value
+      } else {
+        delete query.search
+      }
+      router.replace({ query })
+    }
+  }
+
+  function clearFilters(): void {
+    const cleared: Record<string, unknown> = {}
+    for (const [key, filterDef] of filtersMap.value.entries()) {
+      cleared[key] = filterDef.default ?? null
+    }
+    filterValues.value = cleared
+    searchQuery.value = ''
+    if (persistFilters) {
+      clearSessionFilters(filterSessionKey)
+    }
+    if (syncUrlParams) {
+      const query = { ...route.query } as Record<string, string>
+      for (const key of filtersMap.value.keys()) {
+        delete query[key]
+      }
+      delete query.search
+      router.replace({ query })
+    }
+    page.value = 1
+    loadItems()
+  }
+
+  const filters = computed(() => Array.from(filtersMap.value.values()))
+
+  /**
+   * Check if a filter is at its default value
+   * Used for styling: default = blue (info), modified = orange (warning)
+   */
+  function isFilterAtDefault(name: string): boolean {
+    const filterDef = filtersMap.value.get(name)
+    if (!filterDef) return true
+    const currentValue = filterValues.value[name]
+    const defaultValue = filterDef.default ?? null
+    return currentValue === defaultValue
+  }
+
+  /**
+   * Check if any filter is NOT at its default value (or search is active)
+   * Useful to show a "clear filters" button only when needed
+   */
+  const hasActiveFilters = computed(() => {
+    if (searchQuery.value) return true
+    for (const [name, filterDef] of filtersMap.value.entries()) {
+      const currentValue = filterValues.value[name]
+      const defaultValue = filterDef.default ?? null
+      if (currentValue !== defaultValue) return true
+    }
+    return false
+  })
+
+  function initFromRegistry(): void {
+    if (!autoLoadFilters) return
+
+    const entityConfig = entityFilters[entityName]
+    if (!entityConfig) return
+
+    if (entityConfig.search) {
+      setSearch(entityConfig.search)
+    }
+
+    if (entityConfig.filters) {
+      for (const filterDef of entityConfig.filters) {
+        addFilter(filterDef.name, filterDef)
+      }
+    }
+  }
+
+  async function loadFilterOptions(): Promise<void> {
+    // Process filters configured directly via addFilter() (smart filter modes)
+    for (const [filterName, filterDef] of filtersMap.value) {
+      if (filterDef.options && filterDef.options.length > 1) continue
+      if (filterDef.optionsFromCache) continue
+
+      try {
+        let rawOptions: Array<{ label: string; value: unknown }> | null = null
+
+        // Mode 1: optionsEntity - fetch from related EntityManager via FilterQuery
+        if (filterDef.optionsEntity) {
+          const filterQuery = new FilterQuery({
+            source: 'entity',
+            entity: filterDef.optionsEntity,
+            label: filterDef.optionLabel || 'name',
+            value: filterDef.optionValue || 'id',
+          })
+
+          rawOptions = (await filterQuery.getOptions(orchestrator)) as Array<{
+            label: string
+            value: unknown
+          }>
+          filterDef._filterQuery = filterQuery
+        }
+        // Mode 2: optionsEndpoint - fetch from API endpoint
+        else if (filterDef.optionsEndpoint) {
+          const endpoint =
+            filterDef.optionsEndpoint === true
+              ? `distinct/${filterName}`
+              : filterDef.optionsEndpoint
+          const response = await manager.request('GET', endpoint as string)
+          const data = Array.isArray(response)
+            ? response
+            : ((response as Record<string, unknown>)?.items as unknown[]) || []
+          rawOptions = data.map((opt) => {
+            if (typeof opt === 'object' && opt !== null) {
+              const o = opt as Record<string, unknown>
+              return {
+                label: (o.label || o.name || String(o.value ?? o.id)) as string,
+                value: o.value ?? o.id,
+              }
+            }
+            return { label: snakeToTitle(String(opt)), value: opt }
+          })
+        }
+
+        if (rawOptions !== null) {
+          const cacheOptions = filterDef.cacheOptions ?? 'auto'
+          let shouldCache = cacheOptions === true
+
+          if (cacheOptions === 'auto') {
+            shouldCache = rawOptions.length <= SMART_FILTER_THRESHOLD
+          }
+
+          const componentType =
+            filterDef.component || (shouldCache ? 'dropdown' : 'autocomplete')
+          const allLabel =
+            filterDef.allLabel || filterDef.placeholder || `All ${snakeToTitle(filterName)}`
+          let finalOptions = [{ label: allLabel, value: null as unknown }, ...rawOptions]
+
+          if (typeof filterDef.processor === 'function') {
+            finalOptions = filterDef.processor(finalOptions)
+          }
+
+          const updatedFilter: FilterConfig = {
+            ...filterDef,
+            options: finalOptions,
+            type: componentType,
+            _cacheOptions: shouldCache,
+            _optionsLoaded: shouldCache,
+          }
+          delete updatedFilter.optionLabel
+          delete updatedFilter.optionValue
+          filtersMap.value.set(filterName, updatedFilter)
+        }
+      } catch (error) {
+        console.warn(`[qdadm] Failed to load options for filter "${filterName}":`, error)
+      }
+    }
+
+    // Invoke filter:alter hooks after all options are loaded
+    await invokeFilterAlterHook()
+
+    // Trigger Vue reactivity
+    filtersMap.value = new Map(filtersMap.value)
+  }
+
+  async function updateCacheBasedFilters(): Promise<void> {
+    if (items.value.length === 0) return
+
+    let hasChanges = false
+
+    for (const [filterName, filterDef] of filtersMap.value) {
+      if (!filterDef.optionsFromCache) continue
+      if (filterDef._optionsLoaded) continue
+      // Skip if filter has an explicit query property (advanced usage)
+      if (filterDef.query) continue
+
+      const currentValue = filterValues.value[filterName]
+      if (currentValue !== null && currentValue !== undefined && currentValue !== '') {
+        continue
+      }
+
+      const fieldName =
+        typeof filterDef.optionsFromCache === 'string' ? filterDef.optionsFromCache : filterName
+
+      const filterQuery = new FilterQuery({
+        source: 'field',
+        field: fieldName,
+      })
+
+      // Provide a minimal mock manager with cached data for field-based filtering
+      filterQuery.setParentManager({
+        _cache: items.value,
+        list: async () => ({ items: items.value }),
+      })
+
+      const rawOptions = (await filterQuery.getOptions()) as Array<{ label: string; value: unknown }>
+
+      const cacheOptions = filterDef.cacheOptions ?? 'auto'
+      let shouldCache = true
+
+      if (cacheOptions === 'auto') {
+        shouldCache = rawOptions.length <= SMART_FILTER_THRESHOLD
+      } else if (cacheOptions === false) {
+        shouldCache = false
+      }
+
+      const componentType =
+        filterDef.component ||
+        (rawOptions.length <= SMART_FILTER_THRESHOLD ? 'dropdown' : 'autocomplete')
+
+      const allLabel =
+        filterDef.allLabel || filterDef.placeholder || `All ${snakeToTitle(filterName)}`
+      let finalOptions = [
+        { label: allLabel, value: null as unknown },
+        ...rawOptions.map((opt) => ({
+          label: snakeToTitle(String(opt.label)),
+          value: opt.value,
+        })),
+      ]
+
+      if (typeof filterDef.processor === 'function') {
+        finalOptions = filterDef.processor(finalOptions)
+      }
+
+      const updatedFilter: FilterConfig = {
+        ...filterDef,
+        options: finalOptions,
+        type: componentType,
+        _cacheOptions: shouldCache,
+        _optionsLoaded: true,
+        _filterQuery: filterQuery,
+      }
+
+      filtersMap.value.set(filterName, updatedFilter)
+      hasChanges = true
+    }
+
+    if (hasChanges) {
+      filtersMap.value = new Map(filtersMap.value)
+    }
+  }
+
+  function restoreFilters(): void {
+    for (const key of filtersMap.value.keys()) {
+      if (route.query[key] !== undefined) {
+        let value: unknown = route.query[key]
+        if (value === 'true') value = true
+        else if (value === 'false') value = false
+        else if (value === 'null') value = null
+        else if (!isNaN(Number(value)) && value !== '') value = Number(value)
+        filterValues.value[key] = value
+      }
+    }
+    if (route.query.search) {
+      searchQuery.value = route.query.search as string
+    }
+  }
+
+  return {
+    filtersMap,
+    filterValues,
+    filters,
+    hasActiveFilters,
+    addFilter,
+    removeFilter,
+    setFilterValue,
+    updateFilters,
+    onFiltersChanged,
+    clearFilters,
+    isFilterAtDefault,
+    initFromRegistry,
+    loadFilterOptions,
+    updateCacheBasedFilters,
+    restoreFilters,
+  }
+}

--- a/packages/qdadm/src/composables/useListPage.ts
+++ b/packages/qdadm/src/composables/useListPage.ts
@@ -33,7 +33,6 @@ import { useConfirm } from 'primevue/useconfirm'
 import { useHooks } from './useHooks.js'
 import { useEntityItemPage, type ParentConfig, type UseEntityItemPageReturn } from './useEntityItemPage.js'
 import { useActiveStack } from '../chain/useActiveStack.js'
-import { FilterQuery } from '../query/FilterQuery'
 import { useI18n } from '../i18n/useI18n'
 import { formatDateOnly } from '../utils/formatters'
 
@@ -85,17 +84,15 @@ export type {
 // Stateless utilities (cookies, session storage, formatters, constants).
 import {
   PAGE_SIZE_OPTIONS,
-  SMART_FILTER_THRESHOLD,
-  clearSessionFilters,
   getSavedPageSize,
   getSessionFilters,
   getSessionSort,
   setSessionSort,
   persistPageSize,
-  setSessionFilters,
-  snakeToTitle,
 } from './useListPage.utils'
 import { useActionRegistry } from './useActionRegistry'
+import { useListFilters } from './useListPage.filters'
+import { useListAlterHooks } from './useListPage.alterHooks'
 import { useOrchestrator } from '../orchestrator/useOrchestrator.js'
 import { createOrchestratorToast } from './useOrchestratorToast'
 
@@ -514,323 +511,45 @@ export function useListPage<T = unknown>(config: UseListPageOptions<T>): UseList
 
   const cards = computed(() => Array.from(cardsMap.value.values()))
 
-  // ============ FILTERS ============
-  const filtersMap = ref<Map<string, FilterConfig>>(new Map())
-  const filterValues = ref<Record<string, unknown>>(savedFilters || {})
-
-  function addFilter(name: string, filterConfig: Omit<FilterConfig, 'name'>): void {
-    filtersMap.value.set(name, {
-      name,
-      type: 'select',
-      placeholder: name,
-      ...filterConfig,
-    })
-    if (filterValues.value[name] === undefined) {
-      filterValues.value[name] = filterConfig.default ?? null
-    }
-  }
-
-  function removeFilter(name: string): void {
-    filtersMap.value.delete(name)
-    delete filterValues.value[name]
-  }
-
-  function setFilterValue(name: string, value: unknown): void {
-    filterValues.value = { ...filterValues.value, [name]: value }
-  }
-
-  function updateFilters(newValues: Record<string, unknown>): void {
-    filterValues.value = { ...filterValues.value, ...newValues }
-    onFiltersChanged()
-  }
-
-  function onFiltersChanged(): void {
-    page.value = 1
-    loadItems()
-    if (persistFilters) {
-      const toPersist: Record<string, unknown> = {}
-      for (const [name, value] of Object.entries(filterValues.value)) {
-        const filterDef = filtersMap.value.get(name)
-        if (
-          filterDef?.persist !== false &&
-          value !== null &&
-          value !== undefined &&
-          value !== ''
-        ) {
-          toPersist[name] = value
-        }
-      }
-      if (searchQuery.value) {
-        toPersist._search = searchQuery.value
-      }
-      setSessionFilters(filterSessionKey, toPersist)
-    }
-    if (syncUrlParams) {
-      const query = { ...route.query } as Record<string, string>
-      for (const [name, value] of Object.entries(filterValues.value)) {
-        if (value !== null && value !== undefined && value !== '') {
-          query[name] = String(value)
-        } else {
-          delete query[name]
-        }
-      }
-      if (searchQuery.value) {
-        query.search = searchQuery.value
-      } else {
-        delete query.search
-      }
-      router.replace({ query })
-    }
-  }
-
-  function clearFilters(): void {
-    const cleared: Record<string, unknown> = {}
-    for (const [key, filterDef] of filtersMap.value.entries()) {
-      cleared[key] = filterDef.default ?? null
-    }
-    filterValues.value = cleared
-    searchQuery.value = ''
-    if (persistFilters) {
-      clearSessionFilters(filterSessionKey)
-    }
-    if (syncUrlParams) {
-      const query = { ...route.query } as Record<string, string>
-      for (const key of filtersMap.value.keys()) {
-        delete query[key]
-      }
-      delete query.search
-      router.replace({ query })
-    }
-    page.value = 1
-    loadItems()
-  }
-
-  const filters = computed(() => Array.from(filtersMap.value.values()))
-
-  /**
-   * Check if a filter is at its default value
-   * Used for styling: default = blue (info), modified = orange (warning)
-   */
-  function isFilterAtDefault(name: string): boolean {
-    const filterDef = filtersMap.value.get(name)
-    if (!filterDef) return true
-    const currentValue = filterValues.value[name]
-    const defaultValue = filterDef.default ?? null
-    return currentValue === defaultValue
-  }
-
-  /**
-   * Check if any filter is NOT at its default value (or search is active)
-   * Useful to show a "clear filters" button only when needed
-   */
-  const hasActiveFilters = computed(() => {
-    if (searchQuery.value) return true
-    for (const [name, filterDef] of filtersMap.value.entries()) {
-      const currentValue = filterValues.value[name]
-      const defaultValue = filterDef.default ?? null
-      if (currentValue !== defaultValue) return true
-    }
-    return false
+  // ============ FILTERS (#1195 — extracted subsystem) ============
+  // invokeFilterAlterHook is a thunk: alterHooks is declared after the
+  // actions section (it needs the action registry) and only runs post-setup.
+  const listFilters = useListFilters({
+    entityName,
+    manager,
+    orchestrator,
+    items: items as Ref<unknown[]>,
+    page,
+    searchQuery,
+    route,
+    router,
+    savedFilters,
+    persistFilters,
+    syncUrlParams,
+    autoLoadFilters,
+    filterSessionKey,
+    entityFilters,
+    loadItems: () => loadItems(),
+    setSearch: (searchCfg) => setSearch(searchCfg),
+    invokeFilterAlterHook: () => alterHooks.invokeFilterAlterHook(),
   })
-
-  // ============ AUTO-LOAD FROM REGISTRY ============
-
-  function initFromRegistry(): void {
-    if (!autoLoadFilters) return
-
-    const entityConfig = entityFilters[entityName]
-    if (!entityConfig) return
-
-    if (entityConfig.search) {
-      setSearch(entityConfig.search)
-    }
-
-    if (entityConfig.filters) {
-      for (const filterDef of entityConfig.filters) {
-        addFilter(filterDef.name, filterDef)
-      }
-    }
-  }
-
-  async function loadFilterOptions(): Promise<void> {
-    // Process filters configured directly via addFilter() (smart filter modes)
-    for (const [filterName, filterDef] of filtersMap.value) {
-      if (filterDef.options && filterDef.options.length > 1) continue
-      if (filterDef.optionsFromCache) continue
-
-      try {
-        let rawOptions: Array<{ label: string; value: unknown }> | null = null
-
-        // Mode 1: optionsEntity - fetch from related EntityManager via FilterQuery
-        if (filterDef.optionsEntity) {
-          const filterQuery = new FilterQuery({
-            source: 'entity',
-            entity: filterDef.optionsEntity,
-            label: filterDef.optionLabel || 'name',
-            value: filterDef.optionValue || 'id',
-          })
-
-          rawOptions = (await filterQuery.getOptions(orchestrator)) as Array<{
-            label: string
-            value: unknown
-          }>
-          filterDef._filterQuery = filterQuery
-        }
-        // Mode 2: optionsEndpoint - fetch from API endpoint
-        else if (filterDef.optionsEndpoint) {
-          const endpoint =
-            filterDef.optionsEndpoint === true
-              ? `distinct/${filterName}`
-              : filterDef.optionsEndpoint
-          const response = await manager.request('GET', endpoint as string)
-          const data = Array.isArray(response)
-            ? response
-            : ((response as Record<string, unknown>)?.items as unknown[]) || []
-          rawOptions = data.map((opt) => {
-            if (typeof opt === 'object' && opt !== null) {
-              const o = opt as Record<string, unknown>
-              return {
-                label: (o.label || o.name || String(o.value ?? o.id)) as string,
-                value: o.value ?? o.id,
-              }
-            }
-            return { label: snakeToTitle(String(opt)), value: opt }
-          })
-        }
-
-        if (rawOptions !== null) {
-          const cacheOptions = filterDef.cacheOptions ?? 'auto'
-          let shouldCache = cacheOptions === true
-
-          if (cacheOptions === 'auto') {
-            shouldCache = rawOptions.length <= SMART_FILTER_THRESHOLD
-          }
-
-          const componentType =
-            filterDef.component || (shouldCache ? 'dropdown' : 'autocomplete')
-          const allLabel =
-            filterDef.allLabel || filterDef.placeholder || `All ${snakeToTitle(filterName)}`
-          let finalOptions = [{ label: allLabel, value: null as unknown }, ...rawOptions]
-
-          if (typeof filterDef.processor === 'function') {
-            finalOptions = filterDef.processor(finalOptions)
-          }
-
-          const updatedFilter: FilterConfig = {
-            ...filterDef,
-            options: finalOptions,
-            type: componentType,
-            _cacheOptions: shouldCache,
-            _optionsLoaded: shouldCache,
-          }
-          delete updatedFilter.optionLabel
-          delete updatedFilter.optionValue
-          filtersMap.value.set(filterName, updatedFilter)
-        }
-      } catch (error) {
-        console.warn(`[qdadm] Failed to load options for filter "${filterName}":`, error)
-      }
-    }
-
-    // Invoke filter:alter hooks after all options are loaded
-    await invokeFilterAlterHook()
-
-    // Trigger Vue reactivity
-    filtersMap.value = new Map(filtersMap.value)
-  }
-
-  async function updateCacheBasedFilters(): Promise<void> {
-    if (items.value.length === 0) return
-
-    let hasChanges = false
-
-    for (const [filterName, filterDef] of filtersMap.value) {
-      if (!filterDef.optionsFromCache) continue
-      if (filterDef._optionsLoaded) continue
-      // Skip if filter has an explicit query property (advanced usage)
-      if (filterDef.query) continue
-
-      const currentValue = filterValues.value[filterName]
-      if (currentValue !== null && currentValue !== undefined && currentValue !== '') {
-        continue
-      }
-
-      const fieldName =
-        typeof filterDef.optionsFromCache === 'string' ? filterDef.optionsFromCache : filterName
-
-      const filterQuery = new FilterQuery({
-        source: 'field',
-        field: fieldName,
-      })
-
-      // Provide a minimal mock manager with cached data for field-based filtering
-      filterQuery.setParentManager({
-        _cache: items.value,
-        list: async () => ({ items: items.value }),
-      })
-
-      const rawOptions = (await filterQuery.getOptions()) as Array<{ label: string; value: unknown }>
-
-      const cacheOptions = filterDef.cacheOptions ?? 'auto'
-      let shouldCache = true
-
-      if (cacheOptions === 'auto') {
-        shouldCache = rawOptions.length <= SMART_FILTER_THRESHOLD
-      } else if (cacheOptions === false) {
-        shouldCache = false
-      }
-
-      const componentType =
-        filterDef.component ||
-        (rawOptions.length <= SMART_FILTER_THRESHOLD ? 'dropdown' : 'autocomplete')
-
-      const allLabel =
-        filterDef.allLabel || filterDef.placeholder || `All ${snakeToTitle(filterName)}`
-      let finalOptions = [
-        { label: allLabel, value: null as unknown },
-        ...rawOptions.map((opt) => ({
-          label: snakeToTitle(String(opt.label)),
-          value: opt.value,
-        })),
-      ]
-
-      if (typeof filterDef.processor === 'function') {
-        finalOptions = filterDef.processor(finalOptions)
-      }
-
-      const updatedFilter: FilterConfig = {
-        ...filterDef,
-        options: finalOptions,
-        type: componentType,
-        _cacheOptions: shouldCache,
-        _optionsLoaded: true,
-        _filterQuery: filterQuery,
-      }
-
-      filtersMap.value.set(filterName, updatedFilter)
-      hasChanges = true
-    }
-
-    if (hasChanges) {
-      filtersMap.value = new Map(filtersMap.value)
-    }
-  }
-
-  function restoreFilters(): void {
-    for (const key of filtersMap.value.keys()) {
-      if (route.query[key] !== undefined) {
-        let value: unknown = route.query[key]
-        if (value === 'true') value = true
-        else if (value === 'false') value = false
-        else if (value === 'null') value = null
-        else if (!isNaN(Number(value)) && value !== '') value = Number(value)
-        filterValues.value[key] = value
-      }
-    }
-    if (route.query.search) {
-      searchQuery.value = route.query.search as string
-    }
-  }
+  const {
+    filtersMap,
+    filterValues,
+    filters,
+    hasActiveFilters,
+    addFilter,
+    removeFilter,
+    setFilterValue,
+    updateFilters,
+    onFiltersChanged,
+    clearFilters,
+    isFilterAtDefault,
+    initFromRegistry,
+    loadFilterOptions,
+    updateCacheBasedFilters,
+    restoreFilters,
+  } = listFilters
 
   // ============ ACTIONS ============
   function resolveValue<T>(value: T | ((row: unknown) => T), row: unknown): T {
@@ -852,7 +571,6 @@ export function useListPage<T = unknown>(config: UseListPageOptions<T>): UseList
       }
     },
   })
-  const actionsMap = actionRegistry.actionsMap
 
   function addAction(name: string, actionConfig: Omit<ActionConfig, 'name'>): void {
     actionRegistry.add({ name, ...actionConfig } as ActionConfig)
@@ -1215,96 +933,18 @@ export function useListPage<T = unknown>(config: UseListPageOptions<T>): UseList
     }
   })
 
-  // ============ HOOKS ============
-
-  async function invokeListAlterHook(): Promise<void> {
-    if (!hooks) return
-
-    const configSnapshot = {
-      entity,
-      columns: Array.from(columnsMap.value.values()),
-      filters: Array.from(filtersMap.value.values()),
-      actions: Array.from(actionsMap.value.values()),
-      headerActions: Array.from(headerActionsMap.value.values()),
-    }
-
-    // Include entity context in the snapshot for hooks
-    const configWithContext = { ...configSnapshot, entity, manager }
-
-    let alteredConfig = await hooks.alter('list:alter', configWithContext)
-
-    const entityHookName = `${entity}:list:alter`
-    if (hooks.hasHook(entityHookName)) {
-      alteredConfig = await hooks.alter(entityHookName, alteredConfig)
-    }
-
-    applyAlteredConfig(alteredConfig)
-  }
-
-  async function invokeFilterAlterHook(): Promise<void> {
-    if (!hooks) return
-
-    const filterSnapshot = {
-      entity,
-      filters: Array.from(filtersMap.value.values()),
-    }
-
-    let alteredFilters = (await hooks.alter('filter:alter', filterSnapshot)) as typeof filterSnapshot
-
-    const entityHookName = `${entity}:filter:alter`
-    if (hooks.hasHook(entityHookName)) {
-      alteredFilters = (await hooks.alter(entityHookName, alteredFilters)) as typeof filterSnapshot
-    }
-
-    if (alteredFilters.filters) {
-      filtersMap.value.clear()
-      for (const filter of alteredFilters.filters) {
-        filtersMap.value.set(filter.name, filter)
-        if (filterValues.value[filter.name] === undefined) {
-          filterValues.value[filter.name] = filter.default ?? null
-        }
-      }
-    }
-  }
-
-  function applyAlteredConfig(alteredConfig: {
-    columns?: ColumnConfig[]
-    filters?: FilterConfig[]
-    actions?: ActionConfig[]
-    headerActions?: HeaderActionConfig[]
-  }): void {
-    if (alteredConfig.columns) {
-      columnsMap.value.clear()
-      for (const col of alteredConfig.columns) {
-        columnsMap.value.set(col.field, col)
-      }
-    }
-
-    if (alteredConfig.filters) {
-      filtersMap.value.clear()
-      for (const filter of alteredConfig.filters) {
-        filtersMap.value.set(filter.name, filter)
-        if (filterValues.value[filter.name] === undefined) {
-          filterValues.value[filter.name] = filter.default ?? null
-        }
-      }
-    }
-
-    if (alteredConfig.actions) {
-      // Route through the registry so the order list stays in sync (#1193)
-      actionRegistry.clear()
-      for (const action of alteredConfig.actions) {
-        actionRegistry.add(action)
-      }
-    }
-
-    if (alteredConfig.headerActions) {
-      headerActionsMap.value.clear()
-      for (const action of alteredConfig.headerActions) {
-        headerActionsMap.value.set(action.name, action)
-      }
-    }
-  }
+  // ============ HOOKS (#1195 — extracted subsystem) ============
+  const alterHooks = useListAlterHooks({
+    hooks,
+    entity,
+    manager,
+    columnsMap,
+    filtersMap,
+    filterValues,
+    headerActionsMap,
+    actionRegistry,
+  })
+  const { invokeListAlterHook } = alterHooks
 
   // ============ LIFECYCLE ============
   initFromRegistry()

--- a/packages/qdadm/src/query/FilterQuery.ts
+++ b/packages/qdadm/src/query/FilterQuery.ts
@@ -73,7 +73,7 @@ interface QueryManagerLike {
 /**
  * Minimal interface for Orchestrator (to avoid circular deps)
  */
-interface QueryOrchestratorLike {
+export interface QueryOrchestratorLike {
   get(name: string): QueryManagerLike | null | undefined
 }
 

--- a/packages/qdadm/tests/composables/useListPageSubsystems.test.js
+++ b/packages/qdadm/tests/composables/useListPageSubsystems.test.js
@@ -1,0 +1,236 @@
+/**
+ * Focused unit tests for the subsystems extracted from useListPage
+ * (qdadm #1195, KPI-8): useListFilters and useListAlterHooks.
+ *
+ * The composables are exercised directly with mocked deps — the composed
+ * behavior inside useListPage stays covered by useListPage.test.js.
+ *
+ * Run: npm test
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ref } from 'vue'
+import { useListFilters } from '../../src/composables/useListPage.filters'
+import { useListAlterHooks } from '../../src/composables/useListPage.alterHooks'
+import { useActionRegistry } from '../../src/composables/useActionRegistry'
+
+beforeEach(() => sessionStorage.clear())
+
+function makeFilterDeps(overrides = {}) {
+  return {
+    entityName: 'books',
+    manager: { request: vi.fn() },
+    orchestrator: null,
+    items: ref([]),
+    page: ref(3),
+    searchQuery: ref(''),
+    route: { query: {} },
+    router: { replace: vi.fn() },
+    savedFilters: null,
+    persistFilters: true,
+    syncUrlParams: false,
+    autoLoadFilters: true,
+    filterSessionKey: 'books',
+    entityFilters: {},
+    loadItems: vi.fn(),
+    setSearch: vi.fn(),
+    invokeFilterAlterHook: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  }
+}
+
+describe('useListFilters (#1195)', () => {
+  it('addFilter applies defaults and seeds the value', () => {
+    const f = useListFilters(makeFilterDeps())
+    f.addFilter('status', { default: 'open' })
+    expect(f.filtersMap.value.get('status')).toMatchObject({
+      name: 'status',
+      type: 'select',
+      placeholder: 'status',
+    })
+    expect(f.filterValues.value.status).toBe('open')
+    expect(f.filters.value).toHaveLength(1)
+  })
+
+  it('updateFilters resets the page, reloads and persists non-empty values', () => {
+    const deps = makeFilterDeps()
+    const f = useListFilters(deps)
+    f.addFilter('status', {})
+    f.updateFilters({ status: 'open' })
+    expect(deps.page.value).toBe(1)
+    expect(deps.loadItems).toHaveBeenCalledOnce()
+    expect(JSON.parse(sessionStorage.getItem('qdadm_filters_books'))).toEqual({ status: 'open' })
+  })
+
+  it('clearFilters restores defaults, clears search and the session', () => {
+    const deps = makeFilterDeps()
+    const f = useListFilters(deps)
+    f.addFilter('status', { default: 'open' })
+    f.updateFilters({ status: 'closed' })
+    deps.searchQuery.value = 'dune'
+    f.clearFilters()
+    expect(f.filterValues.value.status).toBe('open')
+    expect(deps.searchQuery.value).toBe('')
+    expect(sessionStorage.getItem('qdadm_filters_books')).toBeNull()
+  })
+
+  it('isFilterAtDefault and hasActiveFilters track modifications', () => {
+    const deps = makeFilterDeps()
+    const f = useListFilters(deps)
+    f.addFilter('status', { default: null })
+    expect(f.isFilterAtDefault('status')).toBe(true)
+    expect(f.hasActiveFilters.value).toBe(false)
+    f.setFilterValue('status', 'open')
+    expect(f.isFilterAtDefault('status')).toBe(false)
+    expect(f.hasActiveFilters.value).toBe(true)
+  })
+
+  it('initFromRegistry wires search and filters from the injected registry', () => {
+    const deps = makeFilterDeps({
+      entityFilters: {
+        books: {
+          search: { placeholder: 'Search books...' },
+          filters: [{ name: 'genre', options: [{ label: 'SF', value: 'sf' }] }],
+        },
+      },
+    })
+    const f = useListFilters(deps)
+    f.initFromRegistry()
+    expect(deps.setSearch).toHaveBeenCalledWith({ placeholder: 'Search books...' })
+    expect(f.filtersMap.value.has('genre')).toBe(true)
+  })
+
+  it('restoreFilters coerces URL query values (bool/null/number)', () => {
+    const deps = makeFilterDeps({
+      route: { query: { active: 'true', level: '3', ghost: 'null', search: 'dune' } },
+    })
+    const f = useListFilters(deps)
+    f.addFilter('active', {})
+    f.addFilter('level', {})
+    f.addFilter('ghost', {})
+    f.restoreFilters()
+    expect(f.filterValues.value).toMatchObject({ active: true, level: 3, ghost: null })
+    expect(deps.searchQuery.value).toBe('dune')
+  })
+
+  it('loadFilterOptions maps optionsEndpoint responses and calls the alter hook', async () => {
+    const deps = makeFilterDeps({
+      manager: { request: vi.fn().mockResolvedValue(['draft', 'published']) },
+    })
+    const f = useListFilters(deps)
+    f.addFilter('status', { optionsEndpoint: true })
+    await f.loadFilterOptions()
+    expect(deps.manager.request).toHaveBeenCalledWith('GET', 'distinct/status')
+    const def = f.filtersMap.value.get('status')
+    expect(def.options[0]).toMatchObject({ value: null }) // "All ..." entry
+    expect(def.options.slice(1)).toEqual([
+      { label: 'Draft', value: 'draft' },
+      { label: 'Published', value: 'published' },
+    ])
+    expect(deps.invokeFilterAlterHook).toHaveBeenCalledOnce()
+  })
+
+  it('updateCacheBasedFilters builds options from loaded items', async () => {
+    const deps = makeFilterDeps({
+      items: ref([{ region: 'europe' }, { region: 'asia' }, { region: 'europe' }]),
+    })
+    const f = useListFilters(deps)
+    f.addFilter('region', { optionsFromCache: true })
+    await f.updateCacheBasedFilters()
+    const def = f.filtersMap.value.get('region')
+    expect(def._optionsLoaded).toBe(true)
+    const values = def.options.map((o) => o.value)
+    expect(values).toContain('europe')
+    expect(values).toContain('asia')
+  })
+})
+
+function makeHookDeps(hooks) {
+  const actionRegistry = useActionRegistry({
+    defaults: { severity: 'secondary' },
+    resolve: (a) => a,
+  })
+  return {
+    deps: {
+      hooks,
+      entity: 'books',
+      manager: { name: 'books' },
+      columnsMap: ref(new Map()),
+      filtersMap: ref(new Map()),
+      filterValues: ref({}),
+      headerActionsMap: ref(new Map()),
+      actionRegistry,
+    },
+    actionRegistry,
+  }
+}
+
+describe('useListAlterHooks (#1195)', () => {
+  it('is a no-op without a hook registry', async () => {
+    const { deps } = makeHookDeps(null)
+    const h = useListAlterHooks(deps)
+    await expect(h.invokeListAlterHook()).resolves.toBeUndefined()
+    await expect(h.invokeFilterAlterHook()).resolves.toBeUndefined()
+  })
+
+  it('list:alter can add actions — applied through the registry (order stays in sync)', async () => {
+    const hooks = {
+      alter: vi.fn(async (name, config) => ({
+        ...config,
+        actions: [...config.actions, { name: 'custom', label: 'Custom', onClick: () => {} }],
+      })),
+      hasHook: () => false,
+    }
+    const { deps, actionRegistry } = makeHookDeps(hooks)
+    actionRegistry.add({ name: 'edit', label: 'Edit', onClick: () => {} })
+    const h = useListAlterHooks(deps)
+    await h.invokeListAlterHook()
+    expect(actionRegistry.order.value).toEqual(['edit', 'custom'])
+    expect(actionRegistry.actionsMap.value.has('custom')).toBe(true)
+  })
+
+  it('chains the entity-scoped hook after the global one', async () => {
+    const calls = []
+    const hooks = {
+      alter: vi.fn(async (name, config) => {
+        calls.push(name)
+        return config
+      }),
+      hasHook: (name) => name === 'books:list:alter',
+    }
+    const { deps } = makeHookDeps(hooks)
+    const h = useListAlterHooks(deps)
+    await h.invokeListAlterHook()
+    expect(calls).toEqual(['list:alter', 'books:list:alter'])
+  })
+
+  it('filter:alter replaces filters and seeds missing values', async () => {
+    const hooks = {
+      alter: vi.fn(async (name, snapshot) => ({
+        ...snapshot,
+        filters: [{ name: 'status', default: 'open' }],
+      })),
+      hasHook: () => false,
+    }
+    const { deps } = makeHookDeps(hooks)
+    const h = useListAlterHooks(deps)
+    await h.invokeFilterAlterHook()
+    expect(deps.filtersMap.value.get('status')).toMatchObject({ name: 'status' })
+    expect(deps.filterValues.value.status).toBe('open')
+  })
+
+  it('list:alter applies altered columns and header actions', async () => {
+    const hooks = {
+      alter: vi.fn(async (name, config) => ({
+        ...config,
+        columns: [{ field: 'title', header: 'Title' }],
+        headerActions: [{ name: 'export', label: 'Export' }],
+      })),
+      hasHook: () => false,
+    }
+    const { deps } = makeHookDeps(hooks)
+    const h = useListAlterHooks(deps)
+    await h.invokeListAlterHook()
+    expect(deps.columnsMap.value.get('title')).toMatchObject({ header: 'Title' })
+    expect(deps.headerActionsMap.value.get('export')).toMatchObject({ label: 'Export' })
+  })
+})


### PR DESCRIPTION
Executes aiball #1195 ([KPI-8] of the #1187 umbrella). Pure mechanical extraction — no behavior change.

## What moved
| New file | Subsystem |
|---|---|
| `useListPage.filters.ts` — `useListFilters(deps)` | Filter state + the three option-source modes (optionsEntity / optionsEndpoint / optionsFromCache), session persistence, URL sync, registry auto-load, URL restore (~420 lines) |
| `useListPage.alterHooks.ts` — `useListAlterHooks(deps)` | `list:alter` / `filter:alter` global + entity-scoped chaining, applyAlteredConfig (actions through the shared #1193 registry) (~150 lines) |

`useListPage.ts` drops **1557 → 1203 lines** and composes both back in. The `loadFilterOptions → invokeFilterAlterHook` / `hooks → filtersMap` cross-dependency is resolved with a lazy thunk (runs post-setup only).

## Guardrails honored
- Existing `useListPage` tests pass **untouched** (57/57) — the extraction was done under that net.
- Public surface unchanged (incl. `formatDate`, which the ticket suggested removing but is part of the documented return).
- +13 focused unit tests on the extracted composables (option-source modes, persistence, URL coercion, hook chaining, registry order sync).
- Suite **1998 green**, vue-tsc clean, 0 eslint errors, demo builds.
- Changeset patch.

aiball: #1195.