### PR TITLE
feat(types): plug the four consumer-TS holes from the skybot migration (#1253)

### DIFF
--- a/.changeset/ts-consumer-holes.md
+++ b/.changeset/ts-consumer-holes.md
@@ -1,0 +1,21 @@
+---
+"@quazardous/qdadm": minor
+---
+
+Four TypeScript consumer-experience fixes (#1253):
+
+- **`QdadmManagerRegistry`** — consumer-augmentable interface (vue-router
+  `RouteNamedMap` pattern). Declare your entity-name → manager-subclass map
+  once via `declare module '@quazardous/qdadm'` and `getManager('bots')` /
+  `useEntity('bots')` return the concrete subclass; unregistered names keep
+  the historical `EntityManager<T>` fallback.
+- **`StorageResolution` / `ResolvedStorage` exported** from the main barrel —
+  typing a `resolveStorage()` override no longer needs `ReturnType<...>`
+  archaeology. (`undefined` was already legal in the union.)
+- **`baseClass` option in `generateManagers`** — global or per-entity
+  `{ import, name }`; generated managers extend (classMode) or instantiate
+  (instance mode) your own EntityManager subclass instead of the hardwired
+  `EntityManager`.
+- **`VanillaJsonEditor.mode`** accepts `'tree' | 'text' | 'table'` string
+  literals (the JSDoc example finally typechecks); the `Mode` enum is also
+  re-exported from `@quazardous/qdadm/editors`.

--- a/packages/qdadm/src/components/editors/VanillaJsonEditor.vue
+++ b/packages/qdadm/src/components/editors/VanillaJsonEditor.vue
@@ -22,7 +22,13 @@ type JsonValue = Record<string, unknown> | unknown[] | string | null
 
 interface Props {
   modelValue?: JsonValue
-  mode?: Mode
+  /**
+   * Editor mode. String literals are accepted (#1253) so consumers never
+   * need to import the `Mode` enum from vanilla-jsoneditor (which is not
+   * a direct dependency of theirs); `Mode` itself is re-exported from
+   * '@quazardous/qdadm/editors' for those who want it.
+   */
+  mode?: Mode | 'tree' | 'text' | 'table'
   height?: string
   readOnly?: boolean
   mainMenuBar?: boolean
@@ -40,7 +46,7 @@ interface Props {
 
 const props = withDefaults(defineProps<Props>(), {
   modelValue: () => ({}),
-  mode: 'tree' as Mode,
+  mode: 'tree',
   height: '400px',
   readOnly: false,
   mainMenuBar: true,
@@ -100,7 +106,7 @@ onMounted(() => {
     target: containerRef.value,
     props: {
       content,
-      mode: props.mode,
+      mode: props.mode as Mode,
       readOnly: props.readOnly,
       mainMenuBar: props.mainMenuBar,
       navigationBar: props.navigationBar,
@@ -161,9 +167,9 @@ watch(() => props.modelValue, (newVal: JsonValue | undefined) => {
 }, { deep: true })
 
 // Watch mode changes
-watch(() => props.mode, (newMode: Mode | undefined) => {
+watch(() => props.mode, (newMode) => {
   if (editor && newMode) {
-    editor.updateProps({ mode: newMode })
+    editor.updateProps({ mode: newMode as Mode })
   }
 })
 

--- a/packages/qdadm/src/editors/index.ts
+++ b/packages/qdadm/src/editors/index.ts
@@ -10,3 +10,8 @@
 
 export { default as VanillaJsonEditor } from '../components/editors/VanillaJsonEditor.vue'
 export { default as JsonStructuredField } from '../components/editors/JsonStructuredField.vue'
+
+// Re-export the mode enum so consumers who want it don't need to depend on
+// vanilla-jsoneditor directly (#1253). String literals ('tree' | 'text' |
+// 'table') are accepted by VanillaJsonEditor's `mode` prop anyway.
+export { Mode } from 'vanilla-jsoneditor'

--- a/packages/qdadm/src/entity/EntityManager.ts
+++ b/packages/qdadm/src/entity/EntityManager.ts
@@ -34,6 +34,8 @@ import type { NullSortMode } from '../query/clientFilter'
 
 // Re-export public types from types file
 export type {
+  StorageResolution,
+  ResolvedStorage,
   RoutingContext,
   PresaveContext,
   PostsaveContext,

--- a/packages/qdadm/src/gen/generateManagers.test.js
+++ b/packages/qdadm/src/gen/generateManagers.test.js
@@ -436,6 +436,84 @@ describe('generateManagers', () => {
     })
   })
 
+  describe('baseClass option (#1253)', () => {
+    function entityConfig(extra = {}) {
+      return {
+        schema: {
+          name: 'users',
+          endpoint: '/users',
+          fields: {
+            id: { name: 'id', type: 'number' },
+            name: { name: 'name', type: 'text', required: true }
+          }
+        },
+        endpoint: '/users',
+        storageImport: '@quazardous/qdadm',
+        storageClass: 'ApiStorage',
+        ...extra
+      }
+    }
+
+    it('class mode extends the global baseClass and imports it', async () => {
+      await generateManagers({
+        output: testOutputDir,
+        classMode: true,
+        baseClass: { import: '@/managers/SkyEntityManager', name: 'SkyEntityManager' },
+        entities: { users: entityConfig() }
+      })
+
+      const content = await readFile(join(testOutputDir, 'users.ts'), 'utf-8')
+      expect(content).toContain("import { SkyEntityManager } from '@/managers/SkyEntityManager'")
+      expect(content).toContain('extends SkyEntityManager<UsersEntity>')
+      expect(content).not.toContain("import { EntityManager } from '@quazardous/qdadm'")
+      // Options/record types still come from qdadm
+      expect(content).toContain("import type { EntityRecord, EntityManagerOptions } from '@quazardous/qdadm'")
+    })
+
+    it('instance mode instantiates the baseClass', async () => {
+      await generateManagers({
+        output: testOutputDir,
+        baseClass: { import: './base', name: 'MyBase' },
+        entities: { users: entityConfig() }
+      })
+
+      const content = await readFile(join(testOutputDir, 'usersManager.ts'), 'utf-8')
+      expect(content).toContain("import { MyBase } from './base'")
+      expect(content).toContain('new MyBase<UsersEntity>(')
+      expect(content).not.toContain('new EntityManager<UsersEntity>(')
+    })
+
+    it('per-entity baseClass overrides the global one', async () => {
+      await generateManagers({
+        output: testOutputDir,
+        classMode: true,
+        baseClass: { import: './globalBase', name: 'GlobalBase' },
+        entities: {
+          users: entityConfig({
+            baseClass: { import: './localBase', name: 'LocalBase' }
+          })
+        }
+      })
+
+      const content = await readFile(join(testOutputDir, 'users.ts'), 'utf-8')
+      expect(content).toContain("import { LocalBase } from './localBase'")
+      expect(content).toContain('extends LocalBase<UsersEntity>')
+      expect(content).not.toContain('GlobalBase')
+    })
+
+    it('defaults to EntityManager when no baseClass is given', async () => {
+      await generateManagers({
+        output: testOutputDir,
+        classMode: true,
+        entities: { users: entityConfig() }
+      })
+
+      const content = await readFile(join(testOutputDir, 'users.ts'), 'utf-8')
+      expect(content).toContain("import { EntityManager } from '@quazardous/qdadm'")
+      expect(content).toContain('extends EntityManager<UsersEntity>')
+    })
+  })
+
   describe('default output directory', () => {
     it('uses default output when not specified', async () => {
       // This test would write to actual src/generated/managers/

--- a/packages/qdadm/src/gen/generateManagers.ts
+++ b/packages/qdadm/src/gen/generateManagers.ts
@@ -23,6 +23,21 @@ import type { EntityDecorator } from './decorators'
 const DEFAULT_OUTPUT_DIR = 'src/generated/managers/'
 
 /**
+ * Custom base class for generated managers (#1253).
+ *
+ * The class MUST extend EntityManager, stay generic over the entity type
+ * and pass constructor options through — the generated code does
+ * `class Generated<X>Manager extends <name><XEntity>` and calls
+ * `super({ ...schema options, storage, ...options })`.
+ */
+export interface GenerateManagersBaseClass {
+  /** Import specifier (e.g. '@/managers/SkyEntityManager') */
+  import: string
+  /** Exported class name (e.g. 'SkyEntityManager') */
+  name: string
+}
+
+/**
  * Entity configuration for generation
  */
 export interface GenerateManagersEntityConfig {
@@ -40,6 +55,8 @@ export interface GenerateManagersEntityConfig {
   decorators?: EntityDecorator
   /** Generate class instead of instance (for extension) */
   classMode?: boolean
+  /** Base class for this entity's generated manager (overrides global) */
+  baseClass?: GenerateManagersBaseClass
 }
 
 /**
@@ -50,6 +67,8 @@ export interface GenerateManagersConfig {
   output?: string
   /** Generate classes instead of instances (for extension pattern) */
   classMode?: boolean
+  /** Base class for all generated managers (default: EntityManager) */
+  baseClass?: GenerateManagersBaseClass
   /** Entity configurations keyed by entity name */
   entities: Record<string, GenerateManagersEntityConfig>
 }
@@ -175,11 +194,18 @@ function serializeValue(value: unknown, indent: number = 0): string {
 function generateManagerSource(
   entityName: string,
   entityConfig: GenerateManagersEntityConfig,
-  globalOptions: { classMode?: boolean } = {}
+  globalOptions: { classMode?: boolean; baseClass?: GenerateManagersBaseClass } = {}
 ): string {
   const { schema, endpoint, storageImport, storageClass, storageOptions = {}, decorators } = entityConfig
   const classMode = entityConfig.classMode ?? globalOptions.classMode ?? false
   const className = toPascalCase(entityName)
+
+  // Custom base class (#1253): per-entity wins over global, default EntityManager.
+  const baseClass = entityConfig.baseClass ?? globalOptions.baseClass
+  const baseName = baseClass?.name ?? 'EntityManager'
+  const baseImport = baseClass
+    ? `import { ${baseClass.name} } from '${baseClass.import}'`
+    : `import { EntityManager } from '@quazardous/qdadm'`
 
   // Build storage options object
   const fullStorageOptions: Record<string, unknown> = {
@@ -240,7 +266,7 @@ function generateManagerSource(
  * Endpoint: ${endpoint}
  */
 
-import { EntityManager } from '@quazardous/qdadm'
+${baseImport}
 import type { EntityRecord, EntityManagerOptions } from '@quazardous/qdadm'
 import { ${storageClass} } from '${storageImport}'
 
@@ -249,9 +275,9 @@ ${entityInterface}
 /**
  * Generated base manager for ${entityName}
  *
- * @extends EntityManager
+ * @extends ${baseName}
  */
-export class Generated${className}Manager extends EntityManager<${className}Entity> {
+export class Generated${className}Manager extends ${baseName}<${className}Entity> {
   constructor(options: Partial<EntityManagerOptions<${className}Entity>> = {}) {
     super({
       ...${serializeValue(managerOptions, 2)},
@@ -274,7 +300,7 @@ export class Generated${className}Manager extends EntityManager<${className}Enti
  * Endpoint: ${endpoint}
  */
 
-import { EntityManager } from '@quazardous/qdadm'
+${baseImport}
 import type { EntityRecord } from '@quazardous/qdadm'
 import { ${storageClass} } from '${storageImport}'
 
@@ -295,7 +321,7 @@ const storageOptions = ${serializeValue(fullStorageOptions, 0)}
  *
  * Provides CRUD operations for ${entityName} entity.
  */
-export const ${entityName}Manager = new EntityManager<${className}Entity>({
+export const ${entityName}Manager = new ${baseName}<${className}Entity>({
   ...${serializeValue(managerOptions, 0)},
   storage: new ${storageClass}<${className}Entity>(storageOptions)
 })
@@ -349,7 +375,7 @@ export async function generateManagers(config: GenerateManagersConfig): Promise<
   }
 
   const outputDir = config.output || DEFAULT_OUTPUT_DIR
-  const globalOptions = { classMode: config.classMode ?? false }
+  const globalOptions = { classMode: config.classMode ?? false, baseClass: config.baseClass }
   const generatedFiles: string[] = []
 
   // Validate each entity config

--- a/packages/qdadm/src/gen/index.ts
+++ b/packages/qdadm/src/gen/index.ts
@@ -63,4 +63,5 @@ export {
   generateEntityInterface,
   type GenerateManagersConfig,
   type GenerateManagersEntityConfig,
+  type GenerateManagersBaseClass,
 } from './generateManagers'

--- a/packages/qdadm/src/index.ts
+++ b/packages/qdadm/src/index.ts
@@ -96,6 +96,8 @@ export {
   type SeverityMapValue,
   type SeverityMap,
   type RoutingContext,
+  type StorageResolution,
+  type ResolvedStorage,
   type PresaveContext,
   type PostsaveContext,
   type PredeleteContext,
@@ -149,6 +151,30 @@ export type {
 // ORCHESTRATOR
 // ════════════════════════════════════════════════════════════════════════════
 export * from './orchestrator/index'
+
+/**
+ * Typed manager registry (#1253) — augment it from your app to make
+ * `getManager()` / `useEntity()` return your concrete EntityManager
+ * subclasses instead of `EntityManager<EntityRecord>`:
+ *
+ * ```ts
+ * declare module '@quazardous/qdadm' {
+ *   interface QdadmManagerRegistry {
+ *     bots: BotsManager
+ *     botPools: BotPoolsManager
+ *   }
+ * }
+ * ```
+ *
+ * Entity names not declared here keep the current fallback behavior.
+ *
+ * NOTE: deliberately declared in this file (not re-exported from a
+ * sub-module) — TypeScript module augmentation does not merge through
+ * re-export aliases, and consumers augment '@quazardous/qdadm', which
+ * resolves here.
+ */
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export interface QdadmManagerRegistry {}
 
 // ════════════════════════════════════════════════════════════════════════════
 // COMPOSABLES (excluding types that conflict with other modules)

--- a/packages/qdadm/src/orchestrator/useOrchestrator.ts
+++ b/packages/qdadm/src/orchestrator/useOrchestrator.ts
@@ -16,13 +16,24 @@ import { inject } from 'vue'
 import type { Orchestrator } from './Orchestrator'
 import type { EntityManager } from '../entity/EntityManager'
 import type { EntityRecord } from '../types'
+// Type-only circular import: QdadmManagerRegistry must live in the package
+// entry (module augmentation does not merge through re-export aliases).
+import type { QdadmManagerRegistry } from '../index'
 
 /**
  * Return type for useOrchestrator
+ *
+ * `getManager` resolves through the consumer-augmentable
+ * QdadmManagerRegistry first (#1253): a declared entity name returns its
+ * concrete manager subclass; anything else falls back to the historical
+ * `EntityManager<T>` signature.
  */
 export interface UseOrchestratorReturn {
   orchestrator: Orchestrator
-  getManager: <T extends EntityRecord = EntityRecord>(name: string) => EntityManager<T>
+  getManager: {
+    <K extends keyof QdadmManagerRegistry>(name: K): QdadmManagerRegistry[K]
+    <T extends EntityRecord = EntityRecord>(name: string): EntityManager<T>
+  }
   hasManager: (name: string) => boolean
 }
 
@@ -46,8 +57,10 @@ export function useOrchestrator(): UseOrchestratorReturn {
    * Get an EntityManager by name
    * @param name - Entity name
    */
-  function getManager<T extends EntityRecord = EntityRecord>(name: string): EntityManager<T> {
-    return orchestrator.get(name) as EntityManager<T>
+  function getManager<K extends keyof QdadmManagerRegistry>(name: K): QdadmManagerRegistry[K]
+  function getManager<T extends EntityRecord = EntityRecord>(name: string): EntityManager<T>
+  function getManager(name: string): unknown {
+    return orchestrator.get(name)
   }
 
   /**
@@ -74,7 +87,9 @@ export function useOrchestrator(): UseOrchestratorReturn {
  * const { items } = await users.list()
  * ```
  */
-export function useEntity<T extends EntityRecord = EntityRecord>(name: string): EntityManager<T> {
+export function useEntity<K extends keyof QdadmManagerRegistry>(name: K): QdadmManagerRegistry[K]
+export function useEntity<T extends EntityRecord = EntityRecord>(name: string): EntityManager<T>
+export function useEntity(name: string): unknown {
   const { getManager } = useOrchestrator()
-  return getManager<T>(name)
+  return getManager(name)
 }


### PR DESCRIPTION
Executes the accepted plan on aiball #1253 (four API frictions surfaced by typechecking a full qdadm admin).

## Changes

1. **`QdadmManagerRegistry`** — empty consumer-augmentable interface, declared directly in `src/index.ts` (module augmentation does not merge through re-export aliases — the vue → @vue/runtime-core precedent). `getManager` / `useEntity` gain a registry overload; unregistered names keep the historical `EntityManager<T>` signature. Verified with a throwaway consumer-side vue-tsc compile: augmented name returns the subclass, unregistered name falls back (`@ts-expect-error` holds), explicit-generic call style still compiles.
2. **`StorageResolution` / `ResolvedStorage`** exported from the main barrel (the union already accepted `undefined`).
3. **`generateManagers` `baseClass`** option — global + per-entity, classMode `extends` and instance-mode `new`; 4 new tests.
4. **`VanillaJsonEditor.mode`** — accepts string literals, casts at the `vanilla-jsoneditor` boundary; `Mode` re-exported from `/editors`.

## Checks
- 2013 tests green (4 new)
- vue-tsc clean, eslint clean on touched files
- minor changeset staged