### PR TITLE
feat(lists): column() binding helper + OpenAPI label/readOnly inference (#1255)

### DIFF
--- a/.changeset/list-column-binding.md
+++ b/.changeset/list-column-binding.md
@@ -1,0 +1,22 @@
+---
+"@quazardous/qdadm": minor
+---
+
+List column binding + OpenAPI field enrichment (#1255):
+
+- **`column(name, overrides?)`** on `useListPage` — spread onto a PrimeVue
+  `<Column v-bind="list.column('botUuid')">` to derive `field` + `header`
+  from one source while keeping the `#body` template. Header resolution:
+  i18n key > override > inline `addColumn` header > `manager.fields[].label`
+  > humanized field name. Pure read, additive — explicit `#columns` slots
+  and `addColumn` are untouched.
+- **`OpenAPIConnector` opt-in `inferLabels: 'humanize'`** — emit a humanized
+  label (`botUuid` → "Bot Uuid") when a field has no `description`.
+- **`OpenAPIConnector` opt-in `inferReadOnly: true`** — fields present in
+  responses but in no request-body schema become `readOnly: true` (entities
+  without write operations get all fields readOnly); schema-declared
+  `readOnly` always wins.
+- New `humanizeFieldName` util exported from `@quazardous/qdadm/utils`.
+
+Both connector options are off by default: enabling them changes generated
+manager output (by design — regen and commit under your drift gate).

--- a/packages/qdadm/src/composables/useListPage.ts
+++ b/packages/qdadm/src/composables/useListPage.ts
@@ -35,6 +35,7 @@ import { useEntityItemPage, type ParentConfig, type UseEntityItemPageReturn } fr
 import { useActiveStack } from '../chain/useActiveStack.js'
 import { useI18n } from '../i18n/useI18n'
 import { formatDateOnly } from '../utils/formatters'
+import { humanizeFieldName } from '../utils/humanize'
 
 // Import types from dedicated types file
 import type {
@@ -293,6 +294,42 @@ export function useListPage<T = unknown>(config: UseListPageOptions<T>): UseList
       }
     }
   })
+
+  /**
+   * Template-side column binding helper (#1255): spread onto a PrimeVue
+   * `<Column>` so `field` + `header` come from one source instead of being
+   * retyped in every list template:
+   *
+   * ```html
+   * <Column v-bind="list.column('botUuid')" sortable>
+   *   <template #body="{ data }">...</template>
+   * </Column>
+   * ```
+   *
+   * Header resolution: i18n key (`entities.{entity}.fields.{field}`) >
+   * `overrides.header` > inline header given to `addColumn` >
+   * `manager.fields[name].label` > humanized field name. Pure read — it
+   * never registers into columnsMap, so calling it during render is safe.
+   */
+  function column(name: string, overrides: Partial<ColumnConfig> = {}): ColumnConfig {
+    // Depend on the locale so headers re-render on locale change.
+    void i18nLocale.value
+
+    let header: string | undefined
+    if (entity && kernelI18n) {
+      const trace = kernelI18n.resolve(`entities.${entity}.fields.${name}`)
+      if (trace.hit) header = trace.result
+    }
+    const fieldConfig = manager.getFieldConfig?.(name) as { label?: string } | null | undefined
+    header ??=
+      overrides.header ??
+      columnInlineHeaders.get(name) ??
+      fieldConfig?.label ??
+      humanizeFieldName(name)
+
+    const registered = columnsMap.value.get(name)
+    return { ...registered, ...overrides, field: name, header }
+  }
 
   function removeColumn(field: string): void {
     columnsMap.value.delete(field)
@@ -1111,6 +1148,7 @@ export function useListPage<T = unknown>(config: UseListPageOptions<T>): UseList
 
     // Columns
     columns,
+    column,
     addColumn,
     removeColumn,
     updateColumn,

--- a/packages/qdadm/src/composables/useListPage.types.ts
+++ b/packages/qdadm/src/composables/useListPage.types.ts
@@ -347,6 +347,8 @@ export interface UseListPageReturn<T = unknown> {
 
   // Columns
   columns: ComputedRef<ColumnConfig[]>
+  /** v-bind column binding helper (#1255): field + header from one source */
+  column: (name: string, overrides?: Partial<ColumnConfig>) => ColumnConfig
   addColumn: (field: string, config?: Partial<ColumnConfig>) => void
   removeColumn: (field: string) => void
   updateColumn: (field: string, updates: Partial<ColumnConfig>) => void

--- a/packages/qdadm/src/entity/EntityManager.interface.ts
+++ b/packages/qdadm/src/entity/EntityManager.interface.ts
@@ -60,6 +60,8 @@ export interface EntityManagerRead<T = unknown> extends EntityManagerBase<T>, En
   request: (method: string, path: string, options?: { data?: unknown }) => Promise<unknown>
   invalidateCache?: () => void
   localFilterThreshold?: number
+  /** Field config lookup — read-side too since list column binding (#1255) */
+  getFieldConfig?: (name: string) => unknown | null
 }
 
 // ─── CRUD ────────────────────────────────────────────────────────────────────

--- a/packages/qdadm/src/gen/connectors/OpenAPIConnector.test.js
+++ b/packages/qdadm/src/gen/connectors/OpenAPIConnector.test.js
@@ -689,6 +689,155 @@ describe('OpenAPIConnector', () => {
     })
   })
 
+  describe('inference options (#1255)', () => {
+    // /api/bots: GET item + POST with a partial body; lastSeen/uuid are
+    // response-only, name is writable, status declares readOnly in-schema.
+    const botsSpec = {
+      openapi: '3.0.0',
+      paths: {
+        '/api/bots/{id}': {
+          get: {
+            responses: {
+              '200': {
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      properties: {
+                        data: {
+                          type: 'object',
+                          properties: {
+                            uuid: { type: 'string', format: 'uuid' },
+                            name: { type: 'string' },
+                            lastSeen: { type: 'string', format: 'date-time' },
+                            status: { type: 'string', readOnly: true },
+                            notes: { type: 'string', description: 'Operator notes' }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        '/api/bots': {
+          post: {
+            requestBody: {
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    properties: {
+                      name: { type: 'string' },
+                      notes: { type: 'string', description: 'Operator notes' }
+                    }
+                  }
+                }
+              }
+            },
+            responses: {
+              '200': {
+                content: {
+                  'application/json': {
+                    schema: { type: 'object', properties: { data: { type: 'object', properties: { uuid: { type: 'string' } } } } }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    // Read-only entity: no write operation at all
+    const logsSpec = {
+      openapi: '3.0.0',
+      paths: {
+        '/api/logs': {
+          get: {
+            responses: {
+              '200': {
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      properties: {
+                        data: {
+                          type: 'array',
+                          items: {
+                            type: 'object',
+                            properties: {
+                              id: { type: 'string' },
+                              message: { type: 'string' }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    describe('inferLabels', () => {
+      it('is off by default (label only from description)', () => {
+        const connector = new OpenAPIConnector()
+        const bots = connector.parse(botsSpec).find(e => e.name === 'bots')
+
+        expect(bots.fields.lastSeen.label).toBeUndefined()
+        expect(bots.fields.notes.label).toBe('Operator notes')
+      })
+
+      it('humanizes field names when enabled and description is absent', () => {
+        const connector = new OpenAPIConnector({ inferLabels: 'humanize' })
+        const bots = connector.parse(botsSpec).find(e => e.name === 'bots')
+
+        expect(bots.fields.lastSeen.label).toBe('Last Seen')
+        expect(bots.fields.uuid.label).toBe('Uuid')
+        // description still wins
+        expect(bots.fields.notes.label).toBe('Operator notes')
+      })
+    })
+
+    describe('inferReadOnly', () => {
+      it('is off by default (readOnly only from schema)', () => {
+        const connector = new OpenAPIConnector()
+        const bots = connector.parse(botsSpec).find(e => e.name === 'bots')
+
+        expect(bots.fields.lastSeen.readOnly).toBe(false)
+        expect(bots.fields.status.readOnly).toBe(true)
+      })
+
+      it('marks response-only fields readOnly when enabled', () => {
+        const connector = new OpenAPIConnector({ inferReadOnly: true })
+        const bots = connector.parse(botsSpec).find(e => e.name === 'bots')
+
+        // never in a request body → inferred readOnly
+        expect(bots.fields.uuid.readOnly).toBe(true)
+        expect(bots.fields.lastSeen.readOnly).toBe(true)
+        // present in the POST body → stays writable
+        expect(bots.fields.name.readOnly).toBe(false)
+        expect(bots.fields.notes.readOnly).toBe(false)
+        // schema-declared readOnly preserved
+        expect(bots.fields.status.readOnly).toBe(true)
+      })
+
+      it('marks every field readOnly for entities without write operations', () => {
+        const connector = new OpenAPIConnector({ inferReadOnly: true })
+        const logs = connector.parse(logsSpec).find(e => e.name === 'logs')
+
+        expect(logs.fields.id.readOnly).toBe(true)
+        expect(logs.fields.message.readOnly).toBe(true)
+      })
+    })
+  })
+
   describe('extensions option', () => {
     it('adds extensions to all parsed entities', () => {
       const connector = new OpenAPIConnector({

--- a/packages/qdadm/src/gen/connectors/OpenAPIConnector.ts
+++ b/packages/qdadm/src/gen/connectors/OpenAPIConnector.ts
@@ -9,6 +9,7 @@
 
 import { BaseConnector, type ConnectorOptions, type ParseResult, type ParseWarning } from './BaseConnector'
 import { getDefaultType, type CustomMappings } from '../FieldMapper'
+import { humanizeFieldName } from '../../utils/humanize'
 import type { UnifiedEntitySchema, UnifiedFieldSchema, UnifiedFieldType } from '../schema'
 
 /**
@@ -48,6 +49,19 @@ export interface OpenAPIConnectorOptions extends ConnectorOptions {
   operationFilter?: OperationFilter | null
   /** Custom type mappings for FieldMapper */
   customMappings?: CustomMappings
+  /**
+   * Infer a label from the field name when the schema has no `description`
+   * (#1255): 'humanize' turns `botUuid` into "Bot Uuid". Opt-in — it changes
+   * generated output. Default: off (label only from `description`).
+   */
+  inferLabels?: 'humanize' | false
+  /**
+   * Infer `readOnly` from operation shape (#1255): a field that appears in
+   * responses but in no request-body schema is marked `readOnly: true`
+   * (an entity with no write operations gets all fields readOnly). Opt-in —
+   * it changes generated output. Schema-declared `readOnly` always wins.
+   */
+  inferReadOnly?: boolean
 }
 
 /**
@@ -64,6 +78,8 @@ interface EntityWorkingData {
   rawSchema: OpenAPISchema | null
   /** Extracted fields */
   fields: Map<string, UnifiedFieldSchema>
+  /** Field names seen in request-body schemas (for readOnly inference, #1255) */
+  requestFields: Set<string>
 }
 
 /**
@@ -173,6 +189,12 @@ export class OpenAPIConnector extends BaseConnector {
   /** Custom type mappings */
   customMappings: CustomMappings
 
+  /** Label inference mode (#1255) */
+  inferLabels: 'humanize' | false
+
+  /** Whether to infer readOnly from operation shape (#1255) */
+  inferReadOnly: boolean
+
   /**
    * Create a new OpenAPI connector
    *
@@ -185,6 +207,8 @@ export class OpenAPIConnector extends BaseConnector {
     this.dataWrapper = options.dataWrapper ?? 'data'
     this.operationFilter = options.operationFilter || null
     this.customMappings = options.customMappings || {}
+    this.inferLabels = options.inferLabels ?? false
+    this.inferReadOnly = options.inferReadOnly ?? false
   }
 
   /**
@@ -268,6 +292,7 @@ export class OpenAPIConnector extends BaseConnector {
           idField: null,
           rawSchema: null,
           fields: new Map(),
+          requestFields: new Set(),
         })
       }
 
@@ -372,6 +397,8 @@ export class OpenAPIConnector extends BaseConnector {
         const requestSchema = this._extractRequestSchema(op, spec)
         if (requestSchema) {
           this._extractFields(requestSchema, entity.fields, spec, warnings, path)
+          // Track writable field names for readOnly inference (#1255)
+          this._collectFieldNames(requestSchema, spec, entity.requestFields)
         }
       }
     }
@@ -593,6 +620,8 @@ export class OpenAPIConnector extends BaseConnector {
       // Add optional properties
       if (resolvedSchema.description) {
         field.label = resolvedSchema.description
+      } else if (this.inferLabels === 'humanize') {
+        field.label = humanizeFieldName(fieldName)
       }
       if (resolvedSchema.format) {
         field.format = resolvedSchema.format
@@ -615,6 +644,36 @@ export class OpenAPIConnector extends BaseConnector {
       // Handle nested objects (one level only to avoid complexity)
       if (resolvedSchema.type === 'object' && resolvedSchema.properties && !prefix) {
         this._extractFields(resolvedSchema, fields, spec, warnings, sourcePath, fieldName)
+      }
+    }
+  }
+
+  /**
+   * Collect field names from a schema the same way _extractFields names them
+   * (top-level + one-level-nested dotted keys). Used to track which fields
+   * appear in request bodies, for readOnly inference (#1255).
+   *
+   * @private
+   * @param schema - JSON Schema object
+   * @param spec - Full spec for ref resolution
+   * @param into - Set collecting the names
+   * @param prefix - Prefix for nested field names
+   */
+  private _collectFieldNames(
+    schema: OpenAPISchema,
+    spec: OpenAPISpec,
+    into: Set<string>,
+    prefix: string = ''
+  ): void {
+    if (!schema || !schema.properties) return
+
+    for (const [name, propSchema] of Object.entries(schema.properties)) {
+      const fieldName = prefix ? `${prefix}.${name}` : name
+      into.add(fieldName)
+
+      const resolvedSchema = propSchema.$ref ? this._resolveRef(propSchema.$ref, spec) : propSchema
+      if (resolvedSchema?.type === 'object' && resolvedSchema.properties && !prefix) {
+        this._collectFieldNames(resolvedSchema, spec, into, fieldName)
       }
     }
   }
@@ -703,6 +762,17 @@ export class OpenAPIConnector extends BaseConnector {
     const schemas: Map<string, UnifiedEntitySchema> = new Map()
 
     for (const [name, data] of entityData) {
+      // readOnly inference (#1255): a field never seen in a request body is
+      // not writable through this API. Entities without write operations end
+      // up with every field readOnly. Schema-declared readOnly is preserved.
+      if (this.inferReadOnly) {
+        for (const field of data.fields.values()) {
+          if (!field.readOnly && !data.requestFields.has(field.name)) {
+            field.readOnly = true
+          }
+        }
+      }
+
       const schema: UnifiedEntitySchema = {
         name: data.name,
         endpoint: data.endpoint,

--- a/packages/qdadm/src/utils/humanize.ts
+++ b/packages/qdadm/src/utils/humanize.ts
@@ -1,0 +1,26 @@
+/**
+ * Field-name humanization (#1255)
+ *
+ * Turns machine field names into presentable labels:
+ *   'botUuid'      → 'Bot Uuid'
+ *   'created_at'   → 'Created At'
+ *   'filter.botId' → 'Filter Bot Id'
+ *
+ * Shared by the list column binding helper (useListPage.column()) and the
+ * OpenAPI connector's opt-in label inference — dependency-free so the gen
+ * side (node) can import it too.
+ */
+
+/**
+ * Humanize a field name: split camelCase, snake_case, kebab-case and dotted
+ * segments into words, then capitalize each word.
+ */
+export function humanizeFieldName(field: string): string {
+  return field
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .replace(/[_\-.]+/g, ' ')
+    .trim()
+    .split(/\s+/)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ')
+}

--- a/packages/qdadm/src/utils/index.ts
+++ b/packages/qdadm/src/utils/index.ts
@@ -21,6 +21,9 @@ export {
 // Error formatting
 export { formatFetchError, type FetchErrorLike } from './errors'
 
+// Field-name humanization
+export { humanizeFieldName } from './humanize'
+
 // Transformers
 export {
   toKeyValueArray,

--- a/packages/qdadm/tests/composables/useListPage.test.js
+++ b/packages/qdadm/tests/composables/useListPage.test.js
@@ -426,6 +426,61 @@ describe('useListPage - Permission features', () => {
       expect(result.props.value.columns[0].field).toBe('title')
     })
   })
+
+  describe('column() binding helper (#1255)', () => {
+    it('derives field + humanized header for an unknown field', () => {
+      const { result } = createWrapper(() => useListPage({ entity: 'books' }))
+
+      expect(result.column('botUuid')).toEqual({ field: 'botUuid', header: 'Bot Uuid' })
+      expect(result.column('created_at').header).toBe('Created At')
+    })
+
+    it('uses manager.fields label when available', () => {
+      mockManager = createMockManager({
+        getFieldConfig: (name) => (name === 'botUuid' ? { label: 'Bot' } : undefined)
+      })
+      const { result } = createWrapper(() => useListPage({ entity: 'books' }))
+
+      expect(result.column('botUuid').header).toBe('Bot')
+      // Fields without a manager label still humanize
+      expect(result.column('lastSeen').header).toBe('Last Seen')
+    })
+
+    it('overrides.header wins over the manager label', () => {
+      mockManager = createMockManager({
+        getFieldConfig: () => ({ label: 'Bot' })
+      })
+      const { result } = createWrapper(() => useListPage({ entity: 'books' }))
+
+      expect(result.column('botUuid', { header: 'Robot' }).header).toBe('Robot')
+    })
+
+    it('merges registered column extras and keeps the inline header', () => {
+      const { result } = createWrapper(() => useListPage({ entity: 'books' }))
+
+      result.addColumn('title', { header: 'The Title', style: 'min-width: 120px' })
+      const bound = result.column('title')
+
+      expect(bound.field).toBe('title')
+      expect(bound.header).toBe('The Title')
+      expect(bound.style).toBe('min-width: 120px')
+    })
+
+    it('passes overrides through to the binding', () => {
+      const { result } = createWrapper(() => useListPage({ entity: 'books' }))
+
+      const bound = result.column('title', { sortable: true, style: 'width: 1rem' })
+      expect(bound.sortable).toBe(true)
+      expect(bound.style).toBe('width: 1rem')
+    })
+
+    it('does not register the column (pure read)', () => {
+      const { result } = createWrapper(() => useListPage({ entity: 'books' }))
+
+      result.column('botUuid')
+      expect(result.columns.value).toHaveLength(0)
+    })
+  })
 })
 
 describe('useListPage - list:alter hook', () => {


### PR DESCRIPTION
Executes the accepted plan on aiball #1255 (derive the field/header pair of list columns from the manager, plus the connector prerequisite).

## Changes

1. **`column(name, overrides?)`** on `useListPage`:
   ```html
   <Column v-bind="list.column('botUuid')" sortable>
     <template #body="{ data }">...</template>
   </Column>
   ```
   Header chain: i18n `entities.{entity}.fields.{field}` > `overrides.header` > inline `addColumn` header > `manager.fields[name].label` > `humanizeFieldName(name)`. Pure read (render-safe, never registers), locale-reactive. Existing `#columns` usage untouched.
2. **`OpenAPIConnector` `inferLabels: 'humanize'`** (opt-in) — humanized label when `description` is absent; `description` still wins.
3. **`OpenAPIConnector` `inferReadOnly: true`** (opt-in) — request-body field tracking per entity; response-only fields → `readOnly: true`, no-write entities → all readOnly, schema-declared `readOnly` preserved.
4. `getFieldConfig?` added to the `EntityManagerRead` structural view; `humanizeFieldName` shared util.

## Checks
- 2020 tests green (11 new: 6 column(), 5 connector inference)
- vue-tsc clean, eslint clean on touched files
- minor changeset staged; connector options off by default (generated output unchanged unless opted in)