### PR TITLE
refactor(types): flip guaranteed members to required on structural views (#1253 phase 2)

### DIFF
--- a/.changeset/header-shadowing-warning.md
+++ b/.changeset/header-shadowing-warning.md
@@ -1,0 +1,17 @@
+---
+"@quazardous/qdadm": minor
+---
+
+Column header shadowing made loud + consistent (#1255). When an i18n key
+`entities.{entity}.fields.{field}` shadows an explicit header (per-call
+`column()` override or inline `addColumn` header) with a DIFFERENT value, a
+one-shot dev warning announces it (deduped per entity+field; silent when the
+key merely copies the header). The precedence itself is unchanged and now
+documented where it lives: the catalog wins by design — an inline `header`
+is the no-key fallback, not an absolute override; to pin a header, don't
+create the key.
+
+Consistency fix uncovered by the warning's tests: `addColumn` used to let
+the inline header win at registration and only flip to the i18n value on the
+first locale change — silently and inconsistently. The catalog now wins at
+registration too.

--- a/.changeset/structural-views-required.md
+++ b/.changeset/structural-views-required.md
@@ -1,0 +1,23 @@
+---
+"@quazardous/qdadm": minor
+---
+
+Structural views tightened + exported (#1253 phase 2). `query`,
+`invalidateCache`, `getFieldConfig` and `canRead` are now REQUIRED on the
+`EntityManagerRead` / `EntityManagerPermissions` views — they are
+unconditionally implemented on `EntityManager` and called unguarded by list
+pages; the `?` was a #1191 unification leftover that forced consumer-side
+casts on base methods (`.manager.invalidateCache()` no longer needs one).
+The badge/severity capability (`getEntityBadges`, `hasSeverityMap`,
+`getSeverity`, `getSeverityDescriptor`) stays optional by design, documented
+as such. Optionality contract documented in the interface header: required
+iff qdadm composables call it unguarded, plus capability coherence.
+
+The views are now exported from the main barrel (`EntityManagerBase`,
+`EntityManagerPermissions`, `EntityManagerRead`, `EntityManagerCrud`,
+`EntityManagerLike`, `OrchestratorLike`) so consumers can type manager-likes
+and test doubles against the same contract.
+
+Type-only tightening: hand-rolled manager-likes missing the flipped members
+stop compiling (they were one call away from a runtime crash inside list
+pages). No runtime change.

--- a/packages/qdadm/src/composables/useListPage.ts
+++ b/packages/qdadm/src/composables/useListPage.ts
@@ -261,26 +261,47 @@ export function useListPage<T = unknown>(config: UseListPageOptions<T>): UseList
   // when the i18n bundle has no translation for the field.
   const columnInlineHeaders = new Map<string, string | undefined>()
 
+  // One-shot per entity+field (#1255): the catalog winning over an explicit
+  // header is by design, but it must never happen silently — the day a key
+  // appears, the page author learns which inline header it shadows.
+  const warnedHeaderShadows = new Set<string>()
+  function warnHeaderShadow(field: string, i18nValue: string, explicit: string | undefined): void {
+    if (explicit === undefined || explicit === i18nValue) return
+    const key = `${entity}.${field}`
+    if (warnedHeaderShadows.has(key)) return
+    warnedHeaderShadows.add(key)
+    console.warn(
+      `[qdadm] column '${field}' (${entity}): i18n key entities.${entity}.fields.${field} ` +
+        `("${i18nValue}") shadows explicit header ("${explicit}") — the catalog wins by design; ` +
+        `drop the inline header or remove the key.`
+    )
+  }
+
   /**
-   * Resolve a column header: i18n hit on entities.{entity}.fields.{field} wins,
+   * Resolve a column header: i18n hit on entities.{entity}.fields.{field} wins
+   * (the inline `header` is the no-key fallback, not an absolute override),
    * otherwise the inline `header` option, otherwise a capitalized field name.
    */
   function resolveColumnHeader(field: string, inline?: string): string {
     if (entity && kernelI18n) {
       const trace = kernelI18n.resolve(`entities.${entity}.fields.${field}`)
-      if (trace.hit) return trace.result
+      if (trace.hit) {
+        warnHeaderShadow(field, trace.result, inline)
+        return trace.result
+      }
     }
     return inline || field.charAt(0).toUpperCase() + field.slice(1)
   }
 
   function addColumn(field: string, columnConfig: Partial<ColumnConfig> = {}): void {
     columnInlineHeaders.set(field, columnConfig.header)
+    // Resolved header LAST so the catalog wins at registration too (#1255) —
+    // previously the inline header survived until the first locale change
+    // flipped it to the i18n value, silently and inconsistently.
     columnsMap.value.set(field, {
       field,
-      header: resolveColumnHeader(field, columnConfig.header),
       ...columnConfig,
-      // Re-apply resolved header after spread so it wins over a stale inline.
-      ...(columnConfig.header ? {} : { header: resolveColumnHeader(field) }),
+      header: resolveColumnHeader(field, columnConfig.header),
     })
   }
 
@@ -308,8 +329,17 @@ export function useListPage<T = unknown>(config: UseListPageOptions<T>): UseList
    *
    * Header resolution: i18n key (`entities.{entity}.fields.{field}`) >
    * `overrides.header` > inline header given to `addColumn` >
-   * `manager.fields[name].label` > humanized field name. Pure read — it
-   * never registers into columnsMap, so calling it during render is safe.
+   * `manager.fields[name].label` > humanized field name.
+   *
+   * NOTE the precedence truth (#1255): an inline `header` is the fallback
+   * used when no i18n key exists — NOT an absolute override. The catalog
+   * wins by design (or a hardcoded header would pin the column to one
+   * language); to pin a header, don't create the key. When a key shadows
+   * an explicit header with a different value, a one-shot dev warning
+   * announces it instead of letting the header change silently.
+   *
+   * Pure read — it never registers into columnsMap, so calling it during
+   * render is safe.
    */
   function column(name: string, overrides: Partial<ColumnConfig> = {}): ColumnConfig {
     // Depend on the locale so headers re-render on locale change.
@@ -318,7 +348,13 @@ export function useListPage<T = unknown>(config: UseListPageOptions<T>): UseList
     let header: string | undefined
     if (entity && kernelI18n) {
       const trace = kernelI18n.resolve(`entities.${entity}.fields.${name}`)
-      if (trace.hit) header = trace.result
+      if (trace.hit) {
+        header = trace.result
+        // Both explicit sources are checked: per-call override AND the
+        // inline header registered via addColumn (values compared — a key
+        // that merely copies the header stays silent).
+        warnHeaderShadow(name, trace.result, overrides.header ?? columnInlineHeaders.get(name))
+      }
     }
     const fieldConfig = manager.getFieldConfig(name) as { label?: string } | null | undefined
     header ??=

--- a/packages/qdadm/src/composables/useListPage.ts
+++ b/packages/qdadm/src/composables/useListPage.ts
@@ -320,7 +320,7 @@ export function useListPage<T = unknown>(config: UseListPageOptions<T>): UseList
       const trace = kernelI18n.resolve(`entities.${entity}.fields.${name}`)
       if (trace.hit) header = trace.result
     }
-    const fieldConfig = manager.getFieldConfig?.(name) as { label?: string } | null | undefined
+    const fieldConfig = manager.getFieldConfig(name) as { label?: string } | null | undefined
     header ??=
       overrides.header ??
       columnInlineHeaders.get(name) ??

--- a/packages/qdadm/src/composables/useListPage.types.ts
+++ b/packages/qdadm/src/composables/useListPage.types.ts
@@ -61,6 +61,11 @@ export interface ConfirmService {
  */
 export interface ColumnConfig {
   field: string
+  /**
+   * Column header. When an i18n key `entities.{entity}.fields.{field}`
+   * exists, the catalog WINS — an inline header is the no-key fallback,
+   * not an absolute override (#1255). To pin a header, don't create the key.
+   */
   header?: string
   sortable?: boolean
   style?: string

--- a/packages/qdadm/src/entity/EntityManager.interface.ts
+++ b/packages/qdadm/src/entity/EntityManager.interface.ts
@@ -13,6 +13,15 @@
  *
  * All interfaces accept an optional generic parameter `T` (default: `unknown`)
  * that flows through to method signatures for typed entity data.
+ *
+ * ## Optionality contract (#1253)
+ *
+ * These views describe the IMPLEMENTER'S MINIMUM, not a mirror of the
+ * EntityManager class. A member is REQUIRED iff qdadm's own composables
+ * call it unguarded (or capability coherence demands it — e.g. the four
+ * can* permission checks travel together). A member stays OPTIONAL only
+ * when it is a genuine capability a minimal manager-like need not carry;
+ * the reason is documented inline. `?` means "conditional", never "lazy".
  */
 
 import type { EntityBadge } from './EntityManager.types'
@@ -32,6 +41,9 @@ export interface EntityManagerBase<T = unknown> {
   labelField?: string | ((entity: T) => string)
   readOnly?: boolean
   getEntityLabel: (data: T) => string
+  // Optional BY DESIGN (#1253): part of the badge/severity presentation
+  // capability; call sites guard (e.g. useEntityItemShowPage checks
+  // `if (!manager.getEntityBadges)`).
   getEntityBadges?: (data: T) => Array<{ label: string; severity?: string }>
 }
 
@@ -41,7 +53,10 @@ export interface EntityManagerBase<T = unknown> {
  * Permission checks — used by guards, list pages, forms.
  */
 export interface EntityManagerPermissions<T = unknown> {
-  canRead?: (entity?: T) => boolean
+  // The four checks are ONE capability — a manager-like answering canUpdate
+  // but not canRead is not a smaller contract, it's an incoherent one. The
+  // `?` on canRead was a #1191 leftover (#1253).
+  canRead: (entity?: T) => boolean
   canCreate: () => boolean
   canUpdate: (entity?: T) => boolean
   canDelete: (entity?: T) => boolean
@@ -55,13 +70,18 @@ export interface EntityManagerPermissions<T = unknown> {
 export interface EntityManagerRead<T = unknown> extends EntityManagerBase<T>, EntityManagerPermissions<T> {
   get: (id: string | number, context?: unknown) => Promise<T>
   list: (params?: unknown, context?: unknown) => Promise<{ items: T[]; total?: number; fromCache?: boolean; [key: string]: unknown }>
-  query?: (params?: unknown, options?: { routingContext?: unknown }) => Promise<{ items: T[]; total?: number; fromCache?: boolean; [key: string]: unknown }>
+  // query/invalidateCache/getFieldConfig are required since #1253: they are
+  // unconditionally implemented on the class (prototype-applied) and called
+  // unguarded by list pages — the `?` was a #1191 leftover that forced
+  // consumer-side casts on base methods.
+  query: (params?: unknown, options?: { routingContext?: unknown }) => Promise<{ items: T[]; total?: number; fromCache?: boolean; [key: string]: unknown }>
   delete: (id: string | number, context?: unknown) => Promise<void>
   request: (method: string, path: string, options?: { data?: unknown }) => Promise<unknown>
-  invalidateCache?: () => void
-  localFilterThreshold?: number
+  invalidateCache: () => void
   /** Field config lookup — read-side too since list column binding (#1255) */
-  getFieldConfig?: (name: string) => unknown | null
+  getFieldConfig: (name: string) => unknown | null
+  /** Config-carrying property: always present on the class, VALUE nullable */
+  localFilterThreshold?: number | null
 }
 
 // ─── CRUD ────────────────────────────────────────────────────────────────────
@@ -73,11 +93,14 @@ export interface EntityManagerCrud<T = unknown> extends EntityManagerRead<T> {
   fields?: Record<string, unknown> | unknown[]
   getInitialData: () => Record<string, unknown>
   getFormFields: () => Array<{ name: string; [key: string]: unknown }>
-  getFieldConfig: (name: string) => unknown | null
+  // getFieldConfig inherited (required) from EntityManagerRead since #1253
   resolveReferenceOptions: (fieldName: string) => Promise<unknown[]>
   create: (data: unknown, context?: unknown) => Promise<T>
   update: (id: string | number, data: unknown, context?: unknown) => Promise<T>
   patch: (id: string | number, data: unknown, context?: unknown) => Promise<T>
+  // Optional BY DESIGN (#1253): the severity/badge presentation capability —
+  // a minimal manager-like need not carry it; every qdadm call site guards
+  // (`?.` or truthiness). The canonical class always provides it.
   hasSeverityMap?: (field: string) => boolean
   getSeverity?: (field: string, value: string | number, defaultSeverity?: string) => string
   getSeverityDescriptor?: (field: string, value: string | number, defaultSeverity?: string) => { severity: string; icon?: string; label?: string }

--- a/packages/qdadm/src/index.ts
+++ b/packages/qdadm/src/index.ts
@@ -106,6 +106,17 @@ export {
   type CacheInfo,
 } from './entity/EntityManager'
 
+// Structural manager/orchestrator views (#1253) — the implementer's minimum
+// that composables consume; import these to type manager-likes and test doubles.
+export type {
+  EntityManagerBase,
+  EntityManagerPermissions,
+  EntityManagerRead,
+  EntityManagerCrud,
+  EntityManagerLike,
+  OrchestratorLike,
+} from './entity/EntityManager.interface'
+
 // Re-export core entity types
 export type {
   EntityRecord,

--- a/packages/qdadm/tests/composables/useListPage.test.js
+++ b/packages/qdadm/tests/composables/useListPage.test.js
@@ -9,6 +9,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { ref, nextTick } from 'vue'
 import { mount, flushPromises } from '@vue/test-utils'
 import { useListPage } from '../../src/composables/useListPage'
+import { I18N_INJECTION_KEY } from '../../src/i18n/useI18n'
 import { createHookRegistry } from '../../src/hooks'
 
 // Mock route state that can be changed per test
@@ -481,6 +482,80 @@ describe('useListPage - Permission features', () => {
 
       result.column('botUuid')
       expect(result.columns.value).toHaveLength(0)
+    })
+  })
+
+  describe('header shadowing warning (#1255)', () => {
+    // Wrapper with a kernel i18n mock: `keys` maps full i18n keys to values.
+    function createI18nWrapper(keys) {
+      let result
+      const TestComponent = {
+        template: '<div></div>',
+        setup() {
+          result = useListPage({ entity: 'books' })
+          return result
+        }
+      }
+      const i18nMock = {
+        locale: ref('en'),
+        t: (key) => key,
+        resolve: (key) => (key in keys ? { hit: true, result: keys[key] } : { hit: false })
+      }
+      mount(TestComponent, {
+        global: {
+          provide: {
+            qdadmOrchestrator: mockOrchestrator,
+            qdadmEntityFilters: {},
+            [I18N_INJECTION_KEY]: i18nMock
+          }
+        }
+      })
+      return { result }
+    }
+
+    let warnSpy
+    beforeEach(() => {
+      warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    })
+    afterEach(() => {
+      warnSpy.mockRestore()
+    })
+
+    it('i18n hit wins over the explicit header and warns once per field', () => {
+      const { result } = createI18nWrapper({ 'entities.books.fields.botType': 'Type FR' })
+
+      const bound = result.column('botType', { header: 'Type' })
+      expect(bound.header).toBe('Type FR')
+      result.column('botType', { header: 'Type' }) // re-render: no second warn
+      const shadowWarns = warnSpy.mock.calls.filter(args => String(args[0]).includes('shadows'))
+      expect(shadowWarns).toHaveLength(1)
+      expect(String(shadowWarns[0][0])).toContain('entities.books.fields.botType')
+      expect(String(shadowWarns[0][0])).toContain('"Type"')
+    })
+
+    it('stays silent when the key value matches the explicit header (copy-migration)', () => {
+      const { result } = createI18nWrapper({ 'entities.books.fields.status': 'Status' })
+
+      expect(result.column('status', { header: 'Status' }).header).toBe('Status')
+      expect(warnSpy.mock.calls.filter(args => String(args[0]).includes('shadows'))).toHaveLength(0)
+    })
+
+    it('stays silent when only defaults are shadowed (no explicit header)', () => {
+      const { result } = createI18nWrapper({ 'entities.books.fields.botType': 'Type FR' })
+
+      expect(result.column('botType').header).toBe('Type FR')
+      expect(warnSpy.mock.calls.filter(args => String(args[0]).includes('shadows'))).toHaveLength(0)
+    })
+
+    it('covers the addColumn inline-header path too', () => {
+      const { result } = createI18nWrapper({ 'entities.books.fields.title': 'Titre' })
+
+      result.addColumn('title', { header: 'The Title' })
+      const shadowWarns = warnSpy.mock.calls.filter(args => String(args[0]).includes('shadows'))
+      expect(shadowWarns).toHaveLength(1)
+      expect(String(shadowWarns[0][0])).toContain('"The Title"')
+      // the catalog still wins in the registered column
+      expect(result.columns.value[0].header).toBe('Titre')
     })
   })
 })

--- a/packages/qdadm/tests/composables/useListPage.test.js
+++ b/packages/qdadm/tests/composables/useListPage.test.js
@@ -67,6 +67,8 @@ function createMockManager(options = {}) {
     }),
     delete: vi.fn().mockResolvedValue(undefined),
     invalidateCache: vi.fn(),
+    // Part of the implementer's minimum since #1253 (EntityManagerRead)
+    getFieldConfig: () => null,
     canCreate: vi.fn().mockReturnValue(options.canCreate ?? true),
     canUpdate: vi.fn().mockImplementation((row) => {
       if (typeof options.canUpdate === 'function') return options.canUpdate(row)


### PR DESCRIPTION
Executes the accepted phase-2 plan on aiball #1253 (amended flip-list, field-verified by skybot).

## Changes
- **`EntityManagerRead`**: `query`, `invalidateCache`, `getFieldConfig` required (class-guaranteed, called unguarded by list pages); `localFilterThreshold` widened to `number | null`.
- **`EntityManagerPermissions`**: `canRead` required — rejoins its three `can*` siblings (most visible #1191 leftover).
- **Badge/severity quartet stays optional by design** (`getEntityBadges`, `hasSeverityMap`, `getSeverity`, `getSeverityDescriptor`) — every qdadm call site guards; documented inline so `?` reads *conditional*, never *lazy*.
- **Optionality contract documented** in the interface header: required iff qdadm composables call it unguarded + capability coherence.
- **`column()` drops its mute `getFieldConfig?.()` guard** (would silently absorb the next contract break).
- **Views exported from the main barrel** (`EntityManagerBase/Permissions/Read/Crud`, `EntityManagerLike`, `OrchestratorLike`) so consumers can type manager-likes/test doubles.

## Verification
- vue-tsc 0 errors, eslint clean, 2024 tests green
- Throwaway consumer-side compile: full manager-like passes, one missing the flipped members fails (`@ts-expect-error` holds), severity/badges omission passes
- Pre-validated by skybot's node_modules probe (zero TS2722, no regression; their 4 residual casts fall on release)
- Minor changeset staged (type-only tightening, no runtime change)

---

**Second slice (aiball #1255, plan `w3ut79` accepted):** one-shot dev warning when an i18n key shadows an explicit column header with a different value (covers both explicit sources: `column()` overrides and `addColumn` inline headers; compares values so copy-into-keys migrations stay silent). Docs state the precedence truth (inline header = no-key fallback). Consistency fix uncovered by the tests: `addColumn` used to let the inline header win at registration and flip to the catalog on first locale change — the catalog now wins at registration too. 4 new tests; suite 2028 green; second minor changeset staged.