### PR TITLE
feat(nav): declarative View↔Edit toggle on the breadcrumb terminal (#1332)

### DIFF
--- a/.changeset/breadcrumb-mode-toggle.md
+++ b/.changeset/breadcrumb-mode-toggle.md
@@ -1,0 +1,5 @@
+---
+"@quazardous/qdadm": minor
+---
+
+Declarative View↔Edit navigation on entity pages (#1332): `useNavContext` exposes a `modeToggle` computed (twin-mode route resolved from the semantic breadcrumb terminal, `router.hasRoute`-checked, `canUpdate`-gated on the Edit side, locale-reactive labels via `breadcrumb.view` / `breadcrumb.edit` keys), and `DefaultBreadcrumb` renders it as a toggle next to the terminal crumb — opt-in via `qdadmFeatures.breadcrumbModeToggle: true`. Edit→show navigation stays covered by the form page's own unsaved-changes guard.

--- a/packages/demo/src/main.js
+++ b/packages/demo/src/main.js
@@ -83,6 +83,10 @@ const kernel = new Kernel({
   // Branding
   app: { name: 'Book Manager', shortName: 'BM', version },
 
+  // Features: View↔Edit toggle on the breadcrumb terminal (#1332) —
+  // see it on Books (show ↔ edit pair); permission-gated by canUpdate
+  features: { breadcrumbModeToggle: true },
+
   // PrimeVue
   primevue: { plugin: PrimeVue, theme: Aura },
 

--- a/packages/demo/src/modules/books/BooksModule.js
+++ b/packages/demo/src/modules/books/BooksModule.js
@@ -198,8 +198,11 @@ export class BooksModule extends Module {
     // ════════════════════════════════════════════════════════════════════════
     // Single form pattern: same component for create & edit
     // Route param uses manager.idField ('bookId') automatically
+    // The show page pairs with edit to demo the breadcrumb View↔Edit
+    // toggle (#1332, qdadmFeatures.breadcrumbModeToggle in main.js)
     ctx.crud('books', {
       list: () => import('./pages/BookList.vue'),
+      show: () => import('./pages/BookShow.vue'),
       form: () => import('./pages/BookForm.vue')  // Handles both create & edit
     }, {
       nav: { section: 'Library', icon: 'pi pi-book' }

--- a/packages/demo/src/modules/books/pages/BookShow.vue
+++ b/packages/demo/src/modules/books/pages/BookShow.vue
@@ -1,0 +1,45 @@
+<script setup>
+/**
+ * BookShow - Book detail page using ShowPage builder
+ *
+ * DEMONSTRATES: the breadcrumb View↔Edit mode toggle (#1332).
+ * On this page the terminal breadcrumb crumb grows an "Edit" link (and the
+ * edit form gets the mirror "View" link) because:
+ * - `qdadmFeatures.breadcrumbModeToggle` is enabled (see main.js)
+ * - the twin route (`book-edit`) exists
+ * - the current user passes `canUpdate` — log in as a read-only user and
+ *   the Edit affordance disappears while the page stays reachable
+ *
+ * Genre renders as a badge via the manager's severity map (no local config).
+ */
+import { useEntityItemShowPage, ShowPage, ShowField, PageNav } from '@quazardous/qdadm'
+
+const show = useEntityItemShowPage({ entity: 'books' })
+
+// Generate fields from schema; the genre severity map comes from the manager
+show.generateFields()
+show.updateField('genre', { type: 'badge' })
+
+// Header/footer actions (imperative pair — still works alongside the toggle)
+show.addEditAction()
+show.addBackAction()
+</script>
+
+<template>
+  <ShowPage v-bind="show.props.value" v-on="show.events">
+    <template #nav>
+      <PageNav />
+    </template>
+
+    <template #fields>
+      <ShowField
+        v-for="f in show.fields.value"
+        :key="f.name"
+        :field="f"
+        :value="show.data.value?.[f.name]"
+        horizontal
+        label-width="140px"
+      />
+    </template>
+  </ShowPage>
+</template>

--- a/packages/qdadm/src/components/layout/defaults/DefaultBreadcrumb.vue
+++ b/packages/qdadm/src/components/layout/defaults/DefaultBreadcrumb.vue
@@ -15,6 +15,8 @@ import Breadcrumb from 'primevue/breadcrumb'
 
 interface FeaturesConfig {
   breadcrumb?: boolean
+  /** Opt-in (#1332): render a View↔Edit toggle next to the terminal crumb */
+  breadcrumbModeToggle?: boolean
   [key: string]: unknown
 }
 
@@ -22,7 +24,7 @@ const route = useRoute()
 const features = inject<FeaturesConfig>('qdadmFeatures', { breadcrumb: true })
 
 // Navigation context (breadcrumb + navlinks from route config)
-const { breadcrumb: defaultBreadcrumb, navlinks: defaultNavlinks } = useNavContext()
+const { breadcrumb: defaultBreadcrumb, navlinks: defaultNavlinks, modeToggle } = useNavContext()
 
 // Allow child pages to override breadcrumb/navlinks via provide/inject
 const breadcrumbOverride = inject<Ref<BreadcrumbItem[] | null>>('qdadmBreadcrumbOverride', ref(null))
@@ -39,6 +41,12 @@ const showBreadcrumb = computed<boolean>(() => {
   if (route.name === 'dashboard') return false
   return true
 })
+
+// View↔Edit toggle on the terminal crumb (#1332) — opt-in, and only when
+// useNavContext resolved a reachable, permitted twin-mode route
+const shownModeToggle = computed(() =>
+  features.breadcrumbModeToggle === true ? modeToggle.value : null
+)
 </script>
 
 <template>
@@ -55,6 +63,17 @@ const showBreadcrumb = computed<boolean>(() => {
         </span>
       </template>
     </Breadcrumb>
+
+    <!-- View↔Edit mode toggle (#1332) — plain navigation; the form page's
+         own route-leave guard covers unsaved changes on edit→show -->
+    <RouterLink
+      v-if="shownModeToggle"
+      :to="shownModeToggle.to"
+      class="breadcrumb-mode-toggle"
+    >
+      <i :class="shownModeToggle.target === 'edit' ? 'pi pi-pencil' : 'pi pi-eye'"></i>
+      <span>{{ shownModeToggle.label }}</span>
+    </RouterLink>
 
     <!-- Navlinks (provided by PageNav for child routes) -->
     <div v-if="navlinks.length > 0" class="breadcrumb-navlinks">
@@ -90,6 +109,24 @@ const showBreadcrumb = computed<boolean>(() => {
   align-items: center;
   gap: 0.5rem;
   font-size: 0.875rem;
+}
+
+/* Mode toggle sits right after the crumbs; auto margin keeps navlinks pinned right */
+.breadcrumb-mode-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  margin-left: 0.75rem;
+  margin-right: auto;
+  font-size: 0.875rem;
+  color: var(--p-primary-500, #3b82f6);
+  text-decoration: none;
+  transition: color 0.15s;
+}
+
+.breadcrumb-mode-toggle:hover {
+  color: var(--p-primary-700, #1d4ed8);
+  text-decoration: underline;
 }
 
 .navlinks-separator {

--- a/packages/qdadm/src/composables/index.ts
+++ b/packages/qdadm/src/composables/index.ts
@@ -73,6 +73,7 @@ export {
   type NavChainType,
   type BreadcrumbItem,
   type NavLinkItem,
+  type BreadcrumbModeToggle,
 } from './useNavContext'
 export { useNavigation, type UseNavigationReturn, type NavItem, type NavSection } from './useNavigation'
 export {

--- a/packages/qdadm/src/composables/useNavContext.ts
+++ b/packages/qdadm/src/composables/useNavContext.ts
@@ -21,6 +21,7 @@ import { useRoute, useRouter, type RouteParamsRawGeneric } from 'vue-router'
 import { getSiblingRoutes } from '../module/moduleRegistry'
 import { useSemanticBreadcrumb, type SemanticBreadcrumbItem } from './useSemanticBreadcrumb'
 import { useStackHydrator, type HydratedLevel } from '../chain/useStackHydrator'
+import { useI18n } from '../i18n/useI18n'
 import type { EntityManagerLike, OrchestratorLike } from '../entity/EntityManager.interface'
 
 // #1191 — shared minimal structural views (was: local redeclarations)
@@ -65,6 +66,29 @@ export interface BreadcrumbItem {
 }
 
 /**
+ * View↔Edit toggle for the breadcrumb terminal (#1332)
+ *
+ * Non-null only when the current route is an entity item mode
+ * (`entity-show` / `entity-edit`), the twin-mode route exists
+ * (`${routePrefix}-edit` / `-show` + `router.hasRoute`), and — for the
+ * Edit affordance — `manager.canUpdate()` allows it. The permission check
+ * passes the hydrated entity when available, so ownership-conditional
+ * permissions are honored once the item is loaded.
+ */
+export interface BreadcrumbModeToggle {
+  /** Mode of the current route */
+  current: 'show' | 'edit'
+  /** Mode the toggle navigates to */
+  target: 'show' | 'edit'
+  /** Twin-route location — a plain router.push; any dirty-form protection
+   *  comes from the form page's own onBeforeRouteLeave guard */
+  to: { name: string; params: RouteParamsRawGeneric }
+  /** Locale-reactive label: i18n `breadcrumb.view` / `breadcrumb.edit`,
+   *  falling back to "View" / "Edit" */
+  label: string
+}
+
+/**
  * Nav link item
  */
 export interface NavLinkItem {
@@ -105,6 +129,7 @@ export interface UseNavContextReturn {
   // Navigation
   breadcrumb: ComputedRef<BreadcrumbItem[]>
   navlinks: ComputedRef<NavLinkItem[]>
+  modeToggle: ComputedRef<BreadcrumbModeToggle | null>
 
   // Helpers
   parentConfig: ComputedRef<ParentConfig | undefined>
@@ -124,6 +149,9 @@ export function useNavContext(_options: UseNavContextOptions = {}): UseNavContex
 
   // Stack hydrator for entity data (has async-loaded data and labels)
   const hydrator = useStackHydrator()
+
+  // i18n for the mode-toggle labels (no-op shim outside a kernel)
+  const { i18n: kernelI18n, locale: i18nLocale } = useI18n()
 
   function getManager(entityName: string): EntityManager | null {
     return orchestrator?.get(entityName) ?? null
@@ -414,6 +442,44 @@ export function useNavContext(_options: UseNavContextOptions = {}): UseNavContex
     return null
   })
 
+  // ============================================================================
+  // MODE TOGGLE (#1332)
+  // ============================================================================
+
+  function toggleLabel(target: 'show' | 'edit'): string {
+    const trace = kernelI18n?.resolve(target === 'edit' ? 'breadcrumb.edit' : 'breadcrumb.view')
+    if (trace?.hit) return trace.result
+    return target === 'edit' ? 'Edit' : 'View'
+  }
+
+  const modeToggle = computed<BreadcrumbModeToggle | null>(() => {
+    void i18nLocale.value // label re-resolves on locale change
+
+    const semantic = semanticBreadcrumb.value
+    const terminal = semantic[semantic.length - 1]
+    if (!terminal?.entity || !terminal.id) return null
+    if (terminal.kind !== 'entity-show' && terminal.kind !== 'entity-edit') return null
+
+    const manager = getManager(terminal.entity)
+    if (!manager?.routePrefix) return null
+
+    const current = terminal.kind === 'entity-edit' ? 'edit' : 'show'
+    // Target is the OPPOSITE of the current mode — getDefaultItemRoute's
+    // edit-preference is a landing default, not a toggle.
+    const target = current === 'edit' ? 'show' : 'edit'
+    const twinRoute = `${manager.routePrefix}-${target}`
+    if (!router.hasRoute(twinRoute)) return null
+
+    if (target === 'edit' && !manager.canUpdate(entityData.value ?? undefined)) return null
+
+    return {
+      current,
+      target,
+      to: { name: twinRoute, params: { [manager.idField || 'id']: terminal.id } },
+      label: toggleLabel(target),
+    }
+  })
+
   return {
     // Analysis
     navChain,
@@ -427,6 +493,7 @@ export function useNavContext(_options: UseNavContextOptions = {}): UseNavContex
     // Navigation
     breadcrumb,
     navlinks,
+    modeToggle,
 
     // Helpers
     parentConfig,

--- a/packages/qdadm/src/index.ts
+++ b/packages/qdadm/src/index.ts
@@ -269,6 +269,7 @@ export {
   type NavChainType,
   type BreadcrumbItem,
   type NavLinkItem,
+  type BreadcrumbModeToggle,
 } from './composables/useNavContext'
 export {
   useNavigation,

--- a/packages/qdadm/src/plugin.ts
+++ b/packages/qdadm/src/plugin.ts
@@ -63,6 +63,8 @@ export interface FeaturesConfig {
   auth?: boolean
   poweredBy?: boolean
   breadcrumb?: boolean
+  /** Opt-in (#1332): View↔Edit toggle on the breadcrumb terminal crumb */
+  breadcrumbModeToggle?: boolean
   [key: string]: boolean | undefined
 }
 

--- a/packages/qdadm/tests/components/DefaultBreadcrumb.test.js
+++ b/packages/qdadm/tests/components/DefaultBreadcrumb.test.js
@@ -1,0 +1,103 @@
+/**
+ * Unit tests for DefaultBreadcrumb — View↔Edit mode toggle rendering (#1332)
+ *
+ * The mechanism (twin route, permission, labels) is tested on
+ * useNavContext.modeToggle; here we test the opt-in rendering contract:
+ * qdadmFeatures.breadcrumbModeToggle gates the affordance, and a null
+ * toggle renders nothing even when the feature is on.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { ref } from 'vue'
+import DefaultBreadcrumb from '../../src/components/layout/defaults/DefaultBreadcrumb.vue'
+
+const modeToggleRef = ref(null)
+
+vi.mock('vue-router', () => ({
+  useRoute: () => ({ path: '/bots/1', name: 'bots-show', params: {}, query: {} }),
+  RouterLink: {
+    name: 'RouterLink',
+    props: ['to'],
+    template: '<a class="router-link"><slot /></a>',
+  },
+}))
+
+vi.mock('../../src/composables/useNavContext', () => ({
+  useNavContext: () => ({
+    breadcrumb: ref([{ label: 'Bots', to: { name: 'bots' } }, { label: 'Bot 1' }]),
+    navlinks: ref([]),
+    modeToggle: modeToggleRef,
+  }),
+}))
+
+vi.mock('primevue/breadcrumb', () => ({
+  default: {
+    name: 'Breadcrumb',
+    props: ['model'],
+    template: '<nav class="mock-breadcrumb"></nav>',
+  },
+}))
+
+function mountBreadcrumb({ features } = {}) {
+  return mount(DefaultBreadcrumb, {
+    global: {
+      provide: features === undefined ? {} : { qdadmFeatures: features },
+    },
+  })
+}
+
+describe('DefaultBreadcrumb mode toggle (#1332)', () => {
+  it('renders the toggle when the feature is on and a toggle resolves', () => {
+    modeToggleRef.value = {
+      current: 'show',
+      target: 'edit',
+      to: { name: 'bots-edit', params: { id: '1' } },
+      label: 'Edit',
+    }
+    const wrapper = mountBreadcrumb({
+      features: { breadcrumb: true, breadcrumbModeToggle: true },
+    })
+
+    const toggle = wrapper.find('.breadcrumb-mode-toggle')
+    expect(toggle.exists()).toBe(true)
+    expect(toggle.text()).toContain('Edit')
+    expect(toggle.find('i').classes()).toContain('pi-pencil')
+  })
+
+  it('renders nothing without the opt-in flag (default features)', () => {
+    modeToggleRef.value = {
+      current: 'show',
+      target: 'edit',
+      to: { name: 'bots-edit', params: { id: '1' } },
+      label: 'Edit',
+    }
+    const wrapper = mountBreadcrumb()
+
+    expect(wrapper.find('.breadcrumb-mode-toggle').exists()).toBe(false)
+    // The breadcrumb itself still renders — the toggle is the only delta
+    expect(wrapper.find('.mock-breadcrumb').exists()).toBe(true)
+  })
+
+  it('renders nothing when the toggle is null even with the feature on', () => {
+    modeToggleRef.value = null
+    const wrapper = mountBreadcrumb({
+      features: { breadcrumb: true, breadcrumbModeToggle: true },
+    })
+
+    expect(wrapper.find('.breadcrumb-mode-toggle').exists()).toBe(false)
+  })
+
+  it('uses the eye icon for the View direction', () => {
+    modeToggleRef.value = {
+      current: 'edit',
+      target: 'show',
+      to: { name: 'bots-show', params: { id: '1' } },
+      label: 'View',
+    }
+    const wrapper = mountBreadcrumb({
+      features: { breadcrumb: true, breadcrumbModeToggle: true },
+    })
+
+    expect(wrapper.find('.breadcrumb-mode-toggle i').classes()).toContain('pi-eye')
+  })
+})

--- a/packages/qdadm/tests/composables/useNavContext.test.js
+++ b/packages/qdadm/tests/composables/useNavContext.test.js
@@ -1,0 +1,151 @@
+/**
+ * Tests for useNavContext.modeToggle (#1332)
+ *
+ * The View↔Edit breadcrumb toggle: non-null only on an entity-show/entity-edit
+ * terminal whose twin-mode route exists, permission-gated on the Edit side.
+ */
+import { describe, it, expect } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { defineComponent, h, ref } from 'vue'
+import { createRouter, createMemoryHistory } from 'vue-router'
+import { useNavContext } from '../../src/composables/useNavContext'
+import { I18N_INJECTION_KEY } from '../../src/i18n/useI18n'
+
+const Stub = { template: '<div />' }
+
+function createTestRouter({ withShow = true, withEdit = true, idParam = 'id' } = {}) {
+  const routes = [
+    { path: '/', name: 'home', component: Stub },
+    { path: '/bots', name: 'bots', meta: { entity: 'bots' }, component: Stub },
+    { path: '/bots/create', name: 'bots-create', meta: { entity: 'bots' }, component: Stub },
+  ]
+  if (withShow) {
+    routes.push({
+      path: `/bots/:${idParam}`,
+      name: 'bots-show',
+      meta: { entity: 'bots' },
+      component: Stub,
+    })
+  }
+  if (withEdit) {
+    routes.push({
+      path: `/bots/:${idParam}/edit`,
+      name: 'bots-edit',
+      meta: { entity: 'bots' },
+      component: Stub,
+    })
+  }
+  return createRouter({ history: createMemoryHistory(), routes })
+}
+
+function createManager(overrides = {}) {
+  return {
+    idField: 'id',
+    routePrefix: 'bots',
+    labelPlural: 'Bots',
+    getEntityLabel: () => 'Bot',
+    canUpdate: () => true,
+    ...overrides,
+  }
+}
+
+async function mountNav(router, { manager = createManager(), path = '/bots/1', i18n = null } = {}) {
+  await router.push(path)
+  await router.isReady()
+
+  let nav
+  const Harness = defineComponent({
+    setup() {
+      nav = useNavContext()
+      return () => h('div')
+    },
+  })
+
+  const provide = {
+    qdadmOrchestrator: { get: (name) => (name === 'bots' ? manager : null) },
+    qdadmStackHydrator: { getLevels: () => [] },
+  }
+  if (i18n) provide[I18N_INJECTION_KEY] = i18n
+
+  const wrapper = mount(Harness, { global: { plugins: [router], provide } })
+  await flushPromises()
+  return { nav, wrapper }
+}
+
+describe('useNavContext modeToggle (#1332)', () => {
+  it('offers the Edit toggle on a show page when the edit twin exists', async () => {
+    const { nav } = await mountNav(createTestRouter(), { path: '/bots/1' })
+
+    expect(nav.modeToggle.value).toEqual({
+      current: 'show',
+      target: 'edit',
+      to: { name: 'bots-edit', params: { id: '1' } },
+      label: 'Edit',
+    })
+  })
+
+  it('offers the View toggle on an edit page when the show twin exists', async () => {
+    const { nav } = await mountNav(createTestRouter(), { path: '/bots/1/edit' })
+
+    expect(nav.modeToggle.value).toEqual({
+      current: 'edit',
+      target: 'show',
+      to: { name: 'bots-show', params: { id: '1' } },
+      label: 'View',
+    })
+  })
+
+  it('returns null when the twin-mode route does not exist', async () => {
+    // Edit-only entity: on the edit page, the show twin is missing
+    const { nav } = await mountNav(createTestRouter({ withShow: false }), {
+      path: '/bots/1/edit',
+    })
+
+    expect(nav.modeToggle.value).toBeNull()
+  })
+
+  it('gates the Edit toggle on manager.canUpdate', async () => {
+    const manager = createManager({ canUpdate: () => false })
+    const { nav } = await mountNav(createTestRouter(), { path: '/bots/1', manager })
+
+    expect(nav.modeToggle.value).toBeNull()
+  })
+
+  it('does not gate the View toggle on canUpdate (edit → show always allowed)', async () => {
+    const manager = createManager({ canUpdate: () => false })
+    const { nav } = await mountNav(createTestRouter(), { path: '/bots/1/edit', manager })
+
+    expect(nav.modeToggle.value).toMatchObject({ target: 'show' })
+  })
+
+  it('returns null on non-item terminals (list, create)', async () => {
+    const router = createTestRouter()
+    const { nav: listNav } = await mountNav(router, { path: '/bots' })
+    expect(listNav.modeToggle.value).toBeNull()
+
+    const { nav: createNav } = await mountNav(createTestRouter(), { path: '/bots/create' })
+    expect(createNav.modeToggle.value).toBeNull()
+  })
+
+  it("maps the route param through the manager's idField", async () => {
+    const manager = createManager({ idField: 'uuid' })
+    const { nav } = await mountNav(createTestRouter({ idParam: 'uuid' }), {
+      path: '/bots/abc-42',
+      manager,
+    })
+
+    expect(nav.modeToggle.value.to).toEqual({ name: 'bots-edit', params: { uuid: 'abc-42' } })
+  })
+
+  it('resolves the label from the i18n catalog when the key exists', async () => {
+    const i18n = {
+      locale: ref('fr'),
+      t: (key) => key,
+      resolve: (key) =>
+        key === 'breadcrumb.edit' ? { hit: true, result: 'Éditer' } : { hit: false, result: key },
+    }
+    const { nav } = await mountNav(createTestRouter(), { path: '/bots/1', i18n })
+
+    expect(nav.modeToggle.value.label).toBe('Éditer')
+  })
+})


### PR DESCRIPTION
Implements the accepted plan on aiball #1332 (skybot request).

## What

- **`useNavContext.modeToggle`** — non-null when the semantic breadcrumb terminal is `entity-show`/`entity-edit` with an id, the OPPOSITE mode's twin route exists (`${routePrefix}-edit`/`-show` + `router.hasRoute`), and — for the Edit direction — `manager.canUpdate()` allows (ownership-aware when the item is hydrated). Emits `{ current, target, to, label }`; labels resolve via i18n `breadcrumb.view`/`breadcrumb.edit` with View/Edit fallback, locale-reactive.
- **`DefaultBreadcrumb`** — renders the toggle next to the terminal crumb, **opt-in** via `qdadmFeatures.breadcrumbModeToggle: true`. Zero change when off (default) or when no toggle resolves.
- Plain `router.push` — dirty-form protection on edit→show comes from the form page's own `onBeforeRouteLeave` guard (no toggle-side plumbing).
- `BreadcrumbModeToggle` type exported from composables + main barrels.

## Tests

- `useNavContext.test.js` (new, 8): both directions, missing twin → null, canUpdate gate (edit only), list/create excluded, custom idField param mapping, i18n catalog hit.
- `DefaultBreadcrumb.test.js` (new, 4): opt-in flag gating, null-toggle rendering, direction icons.
- Suite: 2040 green (+12), vue-tsc clean, eslint clean.

Changeset: **minor** (additive feature).