### PR TITLE
feat(nav): parent View/Edit mode links on child-list pages (#1353)

### DIFF
--- a/.changeset/child-page-mode-links.md
+++ b/.changeset/child-page-mode-links.md
@@ -1,0 +1,5 @@
+---
+"@quazardous/qdadm": minor
+---
+
+Mode links on child-list pages (#1353): `useNavContext` gains `modeLinks` — the uniform list the breadcrumb components render at the end of the navlinks group. Item pages keep the single opposite-mode entry (unchanged behavior, `modeToggle` preserved for compatibility); child pages (routes with `meta.parent`) now surface the PARENT item's `View | Edit` pair, each under the same route-existence/`canUpdate`/i18n rules.

--- a/docs/navigation.md
+++ b/docs/navigation.md
@@ -43,7 +43,7 @@ semantic items) — used for custom pages that want a hand-built trail.
 `useNavContext()` turns the semantic trail into render-ready pieces:
 
 ```ts
-const { breadcrumb, navlinks, modeToggle } = useNavContext()
+const { breadcrumb, navlinks, modeToggle, modeLinks } = useNavContext()
 ```
 
 - **`breadcrumb`** — `BreadcrumbItem[]` (label, optional `to`, optional
@@ -54,7 +54,11 @@ const { breadcrumb, navlinks, modeToggle } = useNavContext()
   edit-preference is a landing default for "go to this item", not a mode
   statement).
 - **`navlinks`** — the right-side sibling links (below).
-- **`modeToggle`** — the View↔Edit toggle descriptor (below).
+- **`modeToggle`** — the single View↔Edit toggle descriptor of item pages
+  (kept for compatibility; null elsewhere).
+- **`modeLinks`** — the uniform list the breadcrumb components render: one
+  opposite-mode entry on item pages, the **parent's** View/Edit pair on child
+  pages (below).
 
 Child pages can replace either list via the provided refs
 (`qdadmBreadcrumbOverride`, `qdadmNavlinksOverride`) — `PageNav` uses this.
@@ -110,6 +114,16 @@ Rendering contract (both breadcrumb components):
 - navigation is a plain `router.push`: leaving a dirty edit form triggers the
   form page's own unsaved-changes guard (`useUnsavedChangesGuard`'s
   `onBeforeRouteLeave`) — the toggle needs no plumbing of its own.
+
+### On child pages (#1353)
+
+On a **child-list page** (`/books/:id/loans`) the terminal is the child
+collection — the page is in *neither* mode of the parent item. The navlinks
+group then carries the **parent's** mode links: both `View` and `Edit`
+(each under the same existence/permission rules, parent id in the params,
+`entityData` — the parent item on such pages — feeding the `canUpdate`
+gate). The `Details` navlink keeps its role as the "go back to the item"
+landing default.
 
 The toggle needs the show/edit **pair** to exist. With `ctx.crud()` that
 means declaring both pages:

--- a/docs/navigation.md
+++ b/docs/navigation.md
@@ -83,7 +83,7 @@ mode toggle below is the affordance for that distinction.
 ## View↔Edit mode toggle (opt-in)
 
 When the terminal crumb is `entity-show` or `entity-edit` and the **twin-mode
-route exists**, the navlinks group grows one last entry: a plain text
+route exists**, the navlinks group gains a leading entry: a plain text
 `Edit` / `View` link that switches mode for the same item.
 
 ```js
@@ -107,8 +107,8 @@ Resolution rules (`useNavContext().modeToggle`, null when any fails):
 
 Rendering contract (both breadcrumb components):
 
-- the toggle is the **last pipe-separated entry of the right-side navlinks
-  group**, styled like the other navlinks — plain text, no icon;
+- the mode links **lead the right-side navlinks group** (pipe-separated,
+  sibling tabs follow), styled like the other navlinks — plain text, no icon;
 - labels resolve through i18n keys `breadcrumb.view` / `breadcrumb.edit`
   (fallbacks `View` / `Edit`), locale-reactive;
 - navigation is a plain `router.push`: leaving a dirty edit form triggers the

--- a/packages/qdadm/src/components/layout/AppLayout.vue
+++ b/packages/qdadm/src/components/layout/AppLayout.vue
@@ -395,23 +395,24 @@ const shownModeLinks = computed(() =>
              links (#1332/#1341/#1353) — plain navigation; the form page's own
              route-leave guard covers unsaved changes on edit→show -->
         <div v-if="navlinks.length > 0 || shownModeLinks.length > 0" class="layout-navlinks">
-          <template v-for="(link, index) in navlinks" :key="link.to?.name || index">
+          <!-- mode links lead the group (#j7udkh), sibling tabs follow -->
+          <template v-for="(mode, index) in shownModeLinks" :key="`mode-${mode.target}`">
             <span v-if="index > 0" class="layout-navlinks-separator">|</span>
+            <RouterLink
+              :to="mode.to"
+              class="layout-navlink breadcrumb-mode-toggle"
+            >
+              {{ mode.label }}
+            </RouterLink>
+          </template>
+          <template v-for="(link, index) in navlinks" :key="link.to?.name || index">
+            <span v-if="shownModeLinks.length > 0 || index > 0" class="layout-navlinks-separator">|</span>
             <RouterLink
               :to="link.to"
               class="layout-navlink"
               :class="{ 'layout-navlink--active': link.active }"
             >
               {{ link.label }}
-            </RouterLink>
-          </template>
-          <template v-for="(mode, index) in shownModeLinks" :key="`mode-${mode.target}`">
-            <span v-if="navlinks.length > 0 || index > 0" class="layout-navlinks-separator">|</span>
-            <RouterLink
-              :to="mode.to"
-              class="layout-navlink breadcrumb-mode-toggle"
-            >
-              {{ mode.label }}
             </RouterLink>
           </template>
         </div>

--- a/packages/qdadm/src/components/layout/AppLayout.vue
+++ b/packages/qdadm/src/components/layout/AppLayout.vue
@@ -241,7 +241,7 @@ watch(() => route.fullPath, () => {
 
 // Navigation context (breadcrumb + navlinks from route config)
 // Entity data comes from activeStack (populated by useEntityItemPage/useEntityItemFormPage)
-const { breadcrumb: defaultBreadcrumb, navlinks: defaultNavlinks, modeToggle } = useNavContext()
+const { breadcrumb: defaultBreadcrumb, navlinks: defaultNavlinks, modeLinks } = useNavContext()
 
 // Allow child pages to override breadcrumb/navlinks via provide/inject
 const breadcrumbOverride = ref<BreadcrumbItem[] | null>(null)
@@ -261,10 +261,11 @@ const showBreadcrumb = computed<boolean>(() => {
   return true
 })
 
-// View↔Edit toggle on the terminal crumb (#1332/#1341) — same opt-in contract
-// as DefaultBreadcrumb; this inline breadcrumb must honor the flag too
-const shownModeToggle = computed(() =>
-  features.breadcrumbModeToggle === true ? modeToggle.value : null
+// View↔Edit mode links (#1332/#1341/#1353) — same opt-in contract as
+// DefaultBreadcrumb; single opposite-mode link on item pages, the parent's
+// View/Edit pair on child pages
+const shownModeLinks = computed(() =>
+  features.breadcrumbModeToggle === true ? modeLinks.value : []
 )
 </script>
 
@@ -391,9 +392,9 @@ const shownModeToggle = computed(() =>
         </Breadcrumb>
 
         <!-- Navlinks (provided by PageNav for child routes) + View↔Edit mode
-             toggle (#1332/#1341) — plain navigation; the form page's own
+             links (#1332/#1341/#1353) — plain navigation; the form page's own
              route-leave guard covers unsaved changes on edit→show -->
-        <div v-if="navlinks.length > 0 || shownModeToggle" class="layout-navlinks">
+        <div v-if="navlinks.length > 0 || shownModeLinks.length > 0" class="layout-navlinks">
           <template v-for="(link, index) in navlinks" :key="link.to?.name || index">
             <span v-if="index > 0" class="layout-navlinks-separator">|</span>
             <RouterLink
@@ -404,13 +405,13 @@ const shownModeToggle = computed(() =>
               {{ link.label }}
             </RouterLink>
           </template>
-          <template v-if="shownModeToggle">
-            <span v-if="navlinks.length > 0" class="layout-navlinks-separator">|</span>
+          <template v-for="(mode, index) in shownModeLinks" :key="`mode-${mode.target}`">
+            <span v-if="navlinks.length > 0 || index > 0" class="layout-navlinks-separator">|</span>
             <RouterLink
-              :to="shownModeToggle.to"
+              :to="mode.to"
               class="layout-navlink breadcrumb-mode-toggle"
             >
-              {{ shownModeToggle.label }}
+              {{ mode.label }}
             </RouterLink>
           </template>
         </div>

--- a/packages/qdadm/src/components/layout/defaults/DefaultBreadcrumb.vue
+++ b/packages/qdadm/src/components/layout/defaults/DefaultBreadcrumb.vue
@@ -68,23 +68,24 @@ const shownModeLinks = computed(() =>
          links (#1332/#1341/#1353) — plain navigation; the form page's own
          route-leave guard covers unsaved changes on edit→show -->
     <div v-if="navlinks.length > 0 || shownModeLinks.length > 0" class="breadcrumb-navlinks">
-      <template v-for="(link, index) in navlinks" :key="link.to?.name || index">
+      <!-- mode links lead the group (#j7udkh), sibling tabs follow -->
+      <template v-for="(mode, index) in shownModeLinks" :key="`mode-${mode.target}`">
         <span v-if="index > 0" class="navlinks-separator">|</span>
+        <RouterLink
+          :to="mode.to"
+          class="navlink breadcrumb-mode-toggle"
+        >
+          {{ mode.label }}
+        </RouterLink>
+      </template>
+      <template v-for="(link, index) in navlinks" :key="link.to?.name || index">
+        <span v-if="shownModeLinks.length > 0 || index > 0" class="navlinks-separator">|</span>
         <RouterLink
           :to="link.to"
           class="navlink"
           :class="{ 'navlink--active': link.active }"
         >
           {{ link.label }}
-        </RouterLink>
-      </template>
-      <template v-for="(mode, index) in shownModeLinks" :key="`mode-${mode.target}`">
-        <span v-if="navlinks.length > 0 || index > 0" class="navlinks-separator">|</span>
-        <RouterLink
-          :to="mode.to"
-          class="navlink breadcrumb-mode-toggle"
-        >
-          {{ mode.label }}
         </RouterLink>
       </template>
     </div>

--- a/packages/qdadm/src/components/layout/defaults/DefaultBreadcrumb.vue
+++ b/packages/qdadm/src/components/layout/defaults/DefaultBreadcrumb.vue
@@ -24,7 +24,7 @@ const route = useRoute()
 const features = inject<FeaturesConfig>('qdadmFeatures', { breadcrumb: true })
 
 // Navigation context (breadcrumb + navlinks from route config)
-const { breadcrumb: defaultBreadcrumb, navlinks: defaultNavlinks, modeToggle } = useNavContext()
+const { breadcrumb: defaultBreadcrumb, navlinks: defaultNavlinks, modeLinks } = useNavContext()
 
 // Allow child pages to override breadcrumb/navlinks via provide/inject
 const breadcrumbOverride = inject<Ref<BreadcrumbItem[] | null>>('qdadmBreadcrumbOverride', ref(null))
@@ -42,10 +42,10 @@ const showBreadcrumb = computed<boolean>(() => {
   return true
 })
 
-// View↔Edit toggle on the terminal crumb (#1332) — opt-in, and only when
-// useNavContext resolved a reachable, permitted twin-mode route
-const shownModeToggle = computed(() =>
-  features.breadcrumbModeToggle === true ? modeToggle.value : null
+// View↔Edit mode links (#1332/#1353) — opt-in; single opposite-mode link on
+// item pages, the parent's View/Edit pair on child pages
+const shownModeLinks = computed(() =>
+  features.breadcrumbModeToggle === true ? modeLinks.value : []
 )
 </script>
 
@@ -65,9 +65,9 @@ const shownModeToggle = computed(() =>
     </Breadcrumb>
 
     <!-- Navlinks (provided by PageNav for child routes) + View↔Edit mode
-         toggle (#1332/#1341) — plain navigation; the form page's own
+         links (#1332/#1341/#1353) — plain navigation; the form page's own
          route-leave guard covers unsaved changes on edit→show -->
-    <div v-if="navlinks.length > 0 || shownModeToggle" class="breadcrumb-navlinks">
+    <div v-if="navlinks.length > 0 || shownModeLinks.length > 0" class="breadcrumb-navlinks">
       <template v-for="(link, index) in navlinks" :key="link.to?.name || index">
         <span v-if="index > 0" class="navlinks-separator">|</span>
         <RouterLink
@@ -78,13 +78,13 @@ const shownModeToggle = computed(() =>
           {{ link.label }}
         </RouterLink>
       </template>
-      <template v-if="shownModeToggle">
-        <span v-if="navlinks.length > 0" class="navlinks-separator">|</span>
+      <template v-for="(mode, index) in shownModeLinks" :key="`mode-${mode.target}`">
+        <span v-if="navlinks.length > 0 || index > 0" class="navlinks-separator">|</span>
         <RouterLink
-          :to="shownModeToggle.to"
+          :to="mode.to"
           class="navlink breadcrumb-mode-toggle"
         >
-          {{ shownModeToggle.label }}
+          {{ mode.label }}
         </RouterLink>
       </template>
     </div>

--- a/packages/qdadm/src/composables/useNavContext.ts
+++ b/packages/qdadm/src/composables/useNavContext.ts
@@ -76,9 +76,10 @@ export interface BreadcrumbItem {
  * permissions are honored once the item is loaded.
  */
 export interface BreadcrumbModeToggle {
-  /** Mode of the current route */
-  current: 'show' | 'edit'
-  /** Mode the toggle navigates to */
+  /** Mode of the current route — absent on child pages (#1353), where the
+   *  page is in neither mode of the parent item */
+  current?: 'show' | 'edit'
+  /** Mode the link navigates to */
   target: 'show' | 'edit'
   /** Twin-route location — a plain router.push; any dirty-form protection
    *  comes from the form page's own onBeforeRouteLeave guard */
@@ -130,6 +131,7 @@ export interface UseNavContextReturn {
   breadcrumb: ComputedRef<BreadcrumbItem[]>
   navlinks: ComputedRef<NavLinkItem[]>
   modeToggle: ComputedRef<BreadcrumbModeToggle | null>
+  modeLinks: ComputedRef<BreadcrumbModeToggle[]>
 
   // Helpers
   parentConfig: ComputedRef<ParentConfig | undefined>
@@ -443,7 +445,7 @@ export function useNavContext(_options: UseNavContextOptions = {}): UseNavContex
   })
 
   // ============================================================================
-  // MODE TOGGLE (#1332)
+  // MODE TOGGLE / MODE LINKS (#1332, #1353)
   // ============================================================================
 
   function toggleLabel(target: 'show' | 'edit'): string {
@@ -452,6 +454,26 @@ export function useNavContext(_options: UseNavContextOptions = {}): UseNavContex
     return target === 'edit' ? 'Edit' : 'View'
   }
 
+  /** Build one mode link if its route exists and (for edit) permission allows. */
+  function buildModeLink(
+    manager: EntityManager,
+    target: 'show' | 'edit',
+    id: unknown,
+    permissionEntity: unknown
+  ): BreadcrumbModeToggle | null {
+    const routeName = `${manager.routePrefix}-${target}`
+    if (!router.hasRoute(routeName)) return null
+    if (target === 'edit' && !manager.canUpdate(permissionEntity ?? undefined)) return null
+    return {
+      target,
+      to: { name: routeName, params: { [manager.idField || 'id']: id as string } },
+      label: toggleLabel(target),
+    }
+  }
+
+  // Item pages (#1332): the terminal is entity-show/entity-edit — offer the
+  // OPPOSITE mode (getDefaultItemRoute's edit-preference is a landing
+  // default, not a toggle).
   const modeToggle = computed<BreadcrumbModeToggle | null>(() => {
     void i18nLocale.value // label re-resolves on locale change
 
@@ -464,20 +486,29 @@ export function useNavContext(_options: UseNavContextOptions = {}): UseNavContex
     if (!manager?.routePrefix) return null
 
     const current = terminal.kind === 'entity-edit' ? 'edit' : 'show'
-    // Target is the OPPOSITE of the current mode — getDefaultItemRoute's
-    // edit-preference is a landing default, not a toggle.
     const target = current === 'edit' ? 'show' : 'edit'
-    const twinRoute = `${manager.routePrefix}-${target}`
-    if (!router.hasRoute(twinRoute)) return null
+    const link = buildModeLink(manager, target, terminal.id, entityData.value)
+    return link ? { ...link, current } : null
+  })
 
-    if (target === 'edit' && !manager.canUpdate(entityData.value ?? undefined)) return null
+  // Uniform list for rendering (#1353). Item pages: the single opposite-mode
+  // entry (modeToggle). Child pages (route carries meta.parent): the PARENT
+  // item's applicable pair — the page is in neither mode, so both View and
+  // Edit are offered, each under the same existence/permission rules. On a
+  // child page, `entityData` resolves to the parent item (last item segment
+  // of the chain), so the canUpdate gate is ownership-aware once hydrated.
+  const modeLinks = computed<BreadcrumbModeToggle[]>(() => {
+    const itemToggle = modeToggle.value
+    if (itemToggle) return [itemToggle]
 
-    return {
-      current,
-      target,
-      to: { name: twinRoute, params: { [manager.idField || 'id']: terminal.id } },
-      label: toggleLabel(target),
-    }
+    void i18nLocale.value
+    if (!parentConfig.value || parentId.value == null) return []
+    const manager = getManager(parentConfig.value.entity)
+    if (!manager?.routePrefix) return []
+
+    return (['show', 'edit'] as const)
+      .map((target) => buildModeLink(manager, target, parentId.value, entityData.value))
+      .filter((link): link is BreadcrumbModeToggle => link !== null)
   })
 
   return {
@@ -494,6 +525,7 @@ export function useNavContext(_options: UseNavContextOptions = {}): UseNavContex
     breadcrumb,
     navlinks,
     modeToggle,
+    modeLinks,
 
     // Helpers
     parentConfig,

--- a/packages/qdadm/tests/components/AppLayout.test.js
+++ b/packages/qdadm/tests/components/AppLayout.test.js
@@ -33,10 +33,12 @@ vi.mock('../../src/composables/useNavigation', () => ({
   }),
 }))
 
+const navlinksRef = ref([])
+
 vi.mock('../../src/composables/useNavContext', () => ({
   useNavContext: () => ({
     breadcrumb: ref([{ label: 'Bots', to: { name: 'bots' } }, { label: 'Bot 1' }]),
-    navlinks: ref([]),
+    navlinks: navlinksRef,
     modeLinks: modeLinksRef,
   }),
 }))
@@ -100,6 +102,7 @@ describe('AppLayout inline breadcrumb mode links (#1341/#1353)', () => {
   })
 
   it('renders the parent View|Edit pair on child pages (#1353)', () => {
+    navlinksRef.value = []
     modeLinksRef.value = [
       { target: 'show', to: { name: 'book-show', params: { bookId: '1' } }, label: 'View' },
       { target: 'edit', to: { name: 'book-edit', params: { bookId: '1' } }, label: 'Edit' },
@@ -112,6 +115,26 @@ describe('AppLayout inline breadcrumb mode links (#1341/#1353)', () => {
     expect(links.map((l) => l.text())).toEqual(['View', 'Edit'])
     // pipe separator between the two entries
     expect(wrapper.findAll('.layout-navlinks .layout-navlinks-separator')).toHaveLength(1)
+  })
+
+  it('mode links LEAD the group, sibling tabs follow (#j7udkh)', () => {
+    navlinksRef.value = [
+      { label: 'Info', to: { name: 'book-info' }, active: false },
+      { label: 'Loans', to: { name: 'book-loans' }, active: true },
+    ]
+    modeLinksRef.value = [
+      { target: 'show', to: { name: 'book-show', params: { bookId: '1' } }, label: 'View' },
+      { target: 'edit', to: { name: 'book-edit', params: { bookId: '1' } }, label: 'Edit' },
+    ]
+    const wrapper = mountLayout({
+      features: { breadcrumb: true, breadcrumbModeToggle: true },
+    })
+
+    const all = wrapper.findAll('.layout-navlinks a')
+    expect(all.map((l) => l.text())).toEqual(['View', 'Edit', 'Info', 'Loans'])
+    // separators between every pair of entries
+    expect(wrapper.findAll('.layout-navlinks .layout-navlinks-separator')).toHaveLength(3)
+    navlinksRef.value = []
   })
 
   it('renders nothing without the opt-in flag (default features)', () => {

--- a/packages/qdadm/tests/components/AppLayout.test.js
+++ b/packages/qdadm/tests/components/AppLayout.test.js
@@ -11,7 +11,7 @@ import { mount } from '@vue/test-utils'
 import { ref } from 'vue'
 import AppLayout from '../../src/components/layout/AppLayout.vue'
 
-const modeToggleRef = ref(null)
+const modeLinksRef = ref([])
 
 vi.mock('vue-router', () => ({
   useRouter: () => ({ push: vi.fn() }),
@@ -37,7 +37,7 @@ vi.mock('../../src/composables/useNavContext', () => ({
   useNavContext: () => ({
     breadcrumb: ref([{ label: 'Bots', to: { name: 'bots' } }, { label: 'Bot 1' }]),
     navlinks: ref([]),
-    modeToggle: modeToggleRef,
+    modeLinks: modeLinksRef,
   }),
 }))
 
@@ -83,14 +83,11 @@ function mountLayout({ features } = {}) {
   })
 }
 
-describe('AppLayout inline breadcrumb mode toggle (#1341)', () => {
+describe('AppLayout inline breadcrumb mode links (#1341/#1353)', () => {
   it('renders the toggle in the right-side navlinks block, no icon (#ctgnc4)', () => {
-    modeToggleRef.value = {
-      current: 'show',
-      target: 'edit',
-      to: { name: 'bots-edit', params: { id: '1' } },
-      label: 'Edit',
-    }
+    modeLinksRef.value = [
+      { current: 'show', target: 'edit', to: { name: 'bots-edit', params: { id: '1' } }, label: 'Edit' },
+    ]
     const wrapper = mountLayout({
       features: { breadcrumb: true, breadcrumbModeToggle: true },
     })
@@ -102,13 +99,25 @@ describe('AppLayout inline breadcrumb mode toggle (#1341)', () => {
     expect(toggle.find('i').exists()).toBe(false)
   })
 
+  it('renders the parent View|Edit pair on child pages (#1353)', () => {
+    modeLinksRef.value = [
+      { target: 'show', to: { name: 'book-show', params: { bookId: '1' } }, label: 'View' },
+      { target: 'edit', to: { name: 'book-edit', params: { bookId: '1' } }, label: 'Edit' },
+    ]
+    const wrapper = mountLayout({
+      features: { breadcrumb: true, breadcrumbModeToggle: true },
+    })
+
+    const links = wrapper.findAll('.layout-navlinks .breadcrumb-mode-toggle')
+    expect(links.map((l) => l.text())).toEqual(['View', 'Edit'])
+    // pipe separator between the two entries
+    expect(wrapper.findAll('.layout-navlinks .layout-navlinks-separator')).toHaveLength(1)
+  })
+
   it('renders nothing without the opt-in flag (default features)', () => {
-    modeToggleRef.value = {
-      current: 'show',
-      target: 'edit',
-      to: { name: 'bots-edit', params: { id: '1' } },
-      label: 'Edit',
-    }
+    modeLinksRef.value = [
+      { current: 'show', target: 'edit', to: { name: 'bots-edit', params: { id: '1' } }, label: 'Edit' },
+    ]
     const wrapper = mountLayout()
 
     expect(wrapper.find('.breadcrumb-mode-toggle').exists()).toBe(false)
@@ -116,8 +125,8 @@ describe('AppLayout inline breadcrumb mode toggle (#1341)', () => {
     expect(wrapper.find('.mock-breadcrumb').exists()).toBe(true)
   })
 
-  it('renders nothing when the toggle is null even with the feature on', () => {
-    modeToggleRef.value = null
+  it('renders nothing when no link resolves even with the feature on', () => {
+    modeLinksRef.value = []
     const wrapper = mountLayout({
       features: { breadcrumb: true, breadcrumbModeToggle: true },
     })

--- a/packages/qdadm/tests/components/DefaultBreadcrumb.test.js
+++ b/packages/qdadm/tests/components/DefaultBreadcrumb.test.js
@@ -11,7 +11,7 @@ import { mount } from '@vue/test-utils'
 import { ref } from 'vue'
 import DefaultBreadcrumb from '../../src/components/layout/defaults/DefaultBreadcrumb.vue'
 
-const modeToggleRef = ref(null)
+const modeLinksRef = ref([])
 
 vi.mock('vue-router', () => ({
   useRoute: () => ({ path: '/bots/1', name: 'bots-show', params: {}, query: {} }),
@@ -26,7 +26,7 @@ vi.mock('../../src/composables/useNavContext', () => ({
   useNavContext: () => ({
     breadcrumb: ref([{ label: 'Bots', to: { name: 'bots' } }, { label: 'Bot 1' }]),
     navlinks: ref([]),
-    modeToggle: modeToggleRef,
+    modeLinks: modeLinksRef,
   }),
 }))
 
@@ -46,14 +46,11 @@ function mountBreadcrumb({ features } = {}) {
   })
 }
 
-describe('DefaultBreadcrumb mode toggle (#1332)', () => {
+describe('DefaultBreadcrumb mode links (#1332/#1353)', () => {
   it('renders the toggle in the right-side navlinks block, no icon (#ctgnc4)', () => {
-    modeToggleRef.value = {
-      current: 'show',
-      target: 'edit',
-      to: { name: 'bots-edit', params: { id: '1' } },
-      label: 'Edit',
-    }
+    modeLinksRef.value = [
+      { current: 'show', target: 'edit', to: { name: 'bots-edit', params: { id: '1' } }, label: 'Edit' },
+    ]
     const wrapper = mountBreadcrumb({
       features: { breadcrumb: true, breadcrumbModeToggle: true },
     })
@@ -65,13 +62,24 @@ describe('DefaultBreadcrumb mode toggle (#1332)', () => {
     expect(toggle.find('i').exists()).toBe(false)
   })
 
+  it('renders the parent View|Edit pair on child pages (#1353)', () => {
+    modeLinksRef.value = [
+      { target: 'show', to: { name: 'book-show', params: { bookId: '1' } }, label: 'View' },
+      { target: 'edit', to: { name: 'book-edit', params: { bookId: '1' } }, label: 'Edit' },
+    ]
+    const wrapper = mountBreadcrumb({
+      features: { breadcrumb: true, breadcrumbModeToggle: true },
+    })
+
+    const links = wrapper.findAll('.breadcrumb-navlinks .breadcrumb-mode-toggle')
+    expect(links.map((l) => l.text())).toEqual(['View', 'Edit'])
+    expect(wrapper.findAll('.breadcrumb-navlinks .navlinks-separator')).toHaveLength(1)
+  })
+
   it('renders nothing without the opt-in flag (default features)', () => {
-    modeToggleRef.value = {
-      current: 'show',
-      target: 'edit',
-      to: { name: 'bots-edit', params: { id: '1' } },
-      label: 'Edit',
-    }
+    modeLinksRef.value = [
+      { current: 'show', target: 'edit', to: { name: 'bots-edit', params: { id: '1' } }, label: 'Edit' },
+    ]
     const wrapper = mountBreadcrumb()
 
     expect(wrapper.find('.breadcrumb-mode-toggle').exists()).toBe(false)
@@ -79,28 +87,12 @@ describe('DefaultBreadcrumb mode toggle (#1332)', () => {
     expect(wrapper.find('.mock-breadcrumb').exists()).toBe(true)
   })
 
-  it('renders nothing when the toggle is null even with the feature on', () => {
-    modeToggleRef.value = null
+  it('renders nothing when no link resolves even with the feature on', () => {
+    modeLinksRef.value = []
     const wrapper = mountBreadcrumb({
       features: { breadcrumb: true, breadcrumbModeToggle: true },
     })
 
     expect(wrapper.find('.breadcrumb-mode-toggle').exists()).toBe(false)
-  })
-
-  it('renders the View direction as a plain text link', () => {
-    modeToggleRef.value = {
-      current: 'edit',
-      target: 'show',
-      to: { name: 'bots-show', params: { id: '1' } },
-      label: 'View',
-    }
-    const wrapper = mountBreadcrumb({
-      features: { breadcrumb: true, breadcrumbModeToggle: true },
-    })
-
-    const toggle = wrapper.find('.breadcrumb-mode-toggle')
-    expect(toggle.text()).toBe('View')
-    expect(toggle.find('i').exists()).toBe(false)
   })
 })

--- a/packages/qdadm/tests/composables/useNavContext.test.js
+++ b/packages/qdadm/tests/composables/useNavContext.test.js
@@ -137,6 +137,13 @@ describe('useNavContext modeToggle (#1332)', () => {
     expect(nav.modeToggle.value.to).toEqual({ name: 'bots-edit', params: { uuid: 'abc-42' } })
   })
 
+  it('modeLinks mirrors modeToggle on item pages (single opposite entry)', async () => {
+    const { nav } = await mountNav(createTestRouter(), { path: '/bots/1' })
+
+    expect(nav.modeLinks.value).toHaveLength(1)
+    expect(nav.modeLinks.value[0]).toMatchObject({ current: 'show', target: 'edit' })
+  })
+
   it('resolves the label from the i18n catalog when the key exists', async () => {
     const i18n = {
       locale: ref('fr'),
@@ -147,5 +154,67 @@ describe('useNavContext modeToggle (#1332)', () => {
     const { nav } = await mountNav(createTestRouter(), { path: '/bots/1', i18n })
 
     expect(nav.modeToggle.value.label).toBe('Éditer')
+  })
+})
+
+describe('useNavContext modeLinks on child pages (#1353)', () => {
+  function createChildRouter({ withShow = true, withEdit = true } = {}) {
+    const routes = [
+      { path: '/', name: 'home', component: Stub },
+      { path: '/bots', name: 'bots', meta: { entity: 'bots' }, component: Stub },
+      {
+        path: '/bots/:id/tasks',
+        name: 'bot-tasks',
+        meta: { entity: 'tasks', layout: 'list', parent: { entity: 'bots', param: 'id' } },
+        component: Stub,
+      },
+    ]
+    if (withShow) {
+      routes.push({ path: '/bots/:id', name: 'bots-show', meta: { entity: 'bots' }, component: Stub })
+    }
+    if (withEdit) {
+      routes.push({
+        path: '/bots/:id/edit',
+        name: 'bots-edit',
+        meta: { entity: 'bots' },
+        component: Stub,
+      })
+    }
+    return createRouter({ history: createMemoryHistory(), routes })
+  }
+
+  it("offers the PARENT's View|Edit pair on a child-list page", async () => {
+    const { nav } = await mountNav(createChildRouter(), { path: '/bots/1/tasks' })
+
+    expect(nav.modeToggle.value).toBeNull()
+    expect(nav.modeLinks.value).toEqual([
+      { target: 'show', to: { name: 'bots-show', params: { id: '1' } }, label: 'View' },
+      { target: 'edit', to: { name: 'bots-edit', params: { id: '1' } }, label: 'Edit' },
+    ])
+  })
+
+  it('drops the Edit entry when canUpdate denies', async () => {
+    const manager = createManager({ canUpdate: () => false })
+    const { nav } = await mountNav(createChildRouter(), { path: '/bots/1/tasks', manager })
+
+    expect(nav.modeLinks.value).toEqual([
+      { target: 'show', to: { name: 'bots-show', params: { id: '1' } }, label: 'View' },
+    ])
+  })
+
+  it('drops an entry whose route does not exist', async () => {
+    const { nav } = await mountNav(createChildRouter({ withShow: false }), {
+      path: '/bots/1/tasks',
+    })
+
+    expect(nav.modeLinks.value).toEqual([
+      { target: 'edit', to: { name: 'bots-edit', params: { id: '1' } }, label: 'Edit' },
+    ])
+  })
+
+  it('returns no links on non-child list pages', async () => {
+    const { nav } = await mountNav(createChildRouter(), { path: '/bots' })
+
+    expect(nav.modeLinks.value).toEqual([])
   })
 })


### PR DESCRIPTION
Implements the accepted plan on aiball #1353 (spinoff of #1341, david's reopen).

## What

- **`useNavContext.modeLinks`** — uniform list rendered at the end of the navlinks group by both breadcrumb components:
  - **item pages**: single opposite-mode entry — exactly today's behavior (`modeToggle` preserved for compatibility, still the single-entry view);
  - **child pages** (routes with `meta.parent`): the **parent item's** `View | Edit` pair — the page is in neither mode. Same #1332 rules per entry: twin-route `hasRoute`, `canUpdate` gate (ownership-aware via the hydrated parent item), locale-reactive i18n labels.
- `BreadcrumbModeToggle.current` becomes optional (child entries are in neither mode).
- `docs/navigation.md`: child-page section + `modeLinks` in the contract.

## Demo showcase (verified live)

No demo change needed — Books already has the loans child and the flag: `/books/:id/loans` renders `Info | Loans | View | Edit`; View navigates to `book-show`, Edit to `book-edit` (both click-verified in the running demo).

## Tests

- `useNavContext.test.js` +5: modeLinks single-entry mirror on item pages; child page pair; canUpdate drops Edit; missing route drops its entry; non-child pages empty.
- Component tests reworked to the `modeLinks` contract (+1 two-entry rendering case each).
- Suite 2053 green, vue-tsc clean, eslint 0 errors.

Changeset: **minor** (additive API).