### PR TITLE
refactor(nav): shared NavlinksGroup + dedupe Details vs mode links (#1357)

### DIFF
--- a/docs/navigation.md
+++ b/docs/navigation.md
@@ -69,7 +69,11 @@ On a **child route** (a route with `meta.parent = { entity, param }`, e.g.
 `/books/:bookId/loans`), the right side of the bar shows the parent item's
 tab set:
 
-- **`Details`** — back to the parent item's default route;
+- **`Details`** — back to the parent item's default route (label via i18n key
+  `breadcrumb.details`, fallback `Details`). Note the default route **prefers
+  `-edit`** over `-show` (`getDefaultItemRoute`), so with mode links enabled
+  Details usually points where the `Edit` mode link points — and is then
+  **deduped away** (see below);
 - one link per **sibling route** of the same parent (`getSiblingRoutes`),
   labeled by `meta.navLabel` or the sibling manager's `labelPlural`, with the
   active one highlighted.
@@ -105,12 +109,18 @@ Resolution rules (`useNavContext().modeToggle`, null when any fails):
    ownership-aware once the item is hydrated;
 4. the target is always the **opposite** of the current mode.
 
-Rendering contract (both breadcrumb components):
+Rendering contract (one shared component, `NavlinksGroup`, used by both
+AppLayout's inline breadcrumb and `DefaultBreadcrumb` — #1357):
 
 - the mode links **lead the right-side navlinks group** (pipe-separated,
   sibling tabs follow), styled like the other navlinks — plain text, no icon;
 - labels resolve through i18n keys `breadcrumb.view` / `breadcrumb.edit`
   (fallbacks `View` / `Edit`), locale-reactive;
+- **dedup (#1357)**: a navlink whose target route is already covered by a
+  shown mode link is dropped. In practice this removes the auto `Details`
+  link on child pages (it resolves to the parent's edit route — the same
+  destination as the `Edit` mode link). With the feature flag off, no mode
+  links are shown and every navlink stays (back-compat);
 - navigation is a plain `router.push`: leaving a dirty edit form triggers the
   form page's own unsaved-changes guard (`useUnsavedChangesGuard`'s
   `onBeforeRouteLeave`) — the toggle needs no plumbing of its own.
@@ -122,8 +132,9 @@ collection — the page is in *neither* mode of the parent item. The navlinks
 group then carries the **parent's** mode links: both `View` and `Edit`
 (each under the same existence/permission rules, parent id in the params,
 `entityData` — the parent item on such pages — feeding the `canUpdate`
-gate). The `Details` navlink keeps its role as the "go back to the item"
-landing default.
+gate). The `Details` navlink is deduped when a mode link covers its route
+(#1357); it remains the "go back to the item" affordance only for consumers
+without the feature flag.
 
 The toggle needs the show/edit **pair** to exist. With `ctx.crud()` that
 means declaring both pages:
@@ -138,6 +149,22 @@ ctx.crud('books', {
 
 The imperative per-page actions (`show.addEditAction()`,
 `form.addCancelAction()`) keep working unchanged — the toggle is additive.
+
+## Auto-injected nav affordances — inventory (#1357)
+
+What appears "automatically" around a page, and what is actually opt-in:
+
+| Affordance | Where | Automatic? | Label resolution |
+|---|---|---|---|
+| Breadcrumb trail | breadcrumb bar (left) | yes — derived from the URL + route meta | manager `labelPlural` / `getEntityLabel`, `meta.navLabel` |
+| `Details` link | navlinks group, child pages only | yes — whenever the route has `meta.parent` | i18n `breadcrumb.details`, fallback `Details` |
+| Sibling tabs | navlinks group, child pages only | yes — one per sibling route with `meta.layout: 'list' \| 'page'` | `meta.navLabel` → sibling `labelPlural` → route name |
+| View↔Edit mode links | navlinks group (leading) | **opt-in** — `features.breadcrumbModeToggle` | i18n `breadcrumb.view` / `breadcrumb.edit`, fallbacks `View` / `Edit` |
+| List header create action (e.g. "Add Book") | list page header | **opt-in** — the page calls `list.addCreateAction(label?)` | explicit label, or `Create ${Entity}` |
+
+All navlinks-group entries render through the shared `NavlinksGroup`
+component (exported), which owns the feature gate, the ordering (mode links
+lead) and the dedup rule.
 
 For consumers typing against the API: `BreadcrumbModeToggle`,
 `BreadcrumbItem` and `NavLinkItem` are exported from the main barrel.

--- a/packages/qdadm/src/components/index.ts
+++ b/packages/qdadm/src/components/index.ts
@@ -11,6 +11,7 @@ export { default as Breadcrumb } from './layout/Breadcrumb.vue'
 export { default as PageNav } from './layout/PageNav.vue'
 export { default as Zone } from './layout/Zone.vue'
 export { default as SidebarBox } from './layout/SidebarBox.vue'
+export { default as NavlinksGroup } from './layout/NavlinksGroup.vue'
 
 // Default zone components
 export { default as DefaultHeader } from './layout/defaults/DefaultHeader.vue'

--- a/packages/qdadm/src/components/layout/AppLayout.vue
+++ b/packages/qdadm/src/components/layout/AppLayout.vue
@@ -25,6 +25,7 @@ import Breadcrumb from 'primevue/breadcrumb'
 import UnsavedChangesDialog from '../dialogs/UnsavedChangesDialog.vue'
 import SidebarBox from './SidebarBox.vue'
 import Zone from './Zone.vue'
+import NavlinksGroup from './NavlinksGroup.vue'
 import qdadmLogo from '../../assets/logo.svg'
 import { version as qdadmVersion } from '../../../package.json'
 
@@ -261,12 +262,6 @@ const showBreadcrumb = computed<boolean>(() => {
   return true
 })
 
-// View↔Edit mode links (#1332/#1341/#1353) — same opt-in contract as
-// DefaultBreadcrumb; single opposite-mode link on item pages, the parent's
-// View/Edit pair on child pages
-const shownModeLinks = computed(() =>
-  features.breadcrumbModeToggle === true ? modeLinks.value : []
-)
 </script>
 
 <template>
@@ -392,30 +387,8 @@ const shownModeLinks = computed(() =>
         </Breadcrumb>
 
         <!-- Navlinks (provided by PageNav for child routes) + View↔Edit mode
-             links (#1332/#1341/#1353) — plain navigation; the form page's own
-             route-leave guard covers unsaved changes on edit→show -->
-        <div v-if="navlinks.length > 0 || shownModeLinks.length > 0" class="layout-navlinks">
-          <!-- mode links lead the group (#j7udkh), sibling tabs follow -->
-          <template v-for="(mode, index) in shownModeLinks" :key="`mode-${mode.target}`">
-            <span v-if="index > 0" class="layout-navlinks-separator">|</span>
-            <RouterLink
-              :to="mode.to"
-              class="layout-navlink breadcrumb-mode-toggle"
-            >
-              {{ mode.label }}
-            </RouterLink>
-          </template>
-          <template v-for="(link, index) in navlinks" :key="link.to?.name || index">
-            <span v-if="shownModeLinks.length > 0 || index > 0" class="layout-navlinks-separator">|</span>
-            <RouterLink
-              :to="link.to"
-              class="layout-navlink"
-              :class="{ 'layout-navlink--active': link.active }"
-            >
-              {{ link.label }}
-            </RouterLink>
-          </template>
-        </div>
+             links (#1332/#1341/#1353) — shared rendering + dedup (#1357) -->
+        <NavlinksGroup :navlinks="navlinks" :mode-links="modeLinks" variant="layout" />
       </div>
 
       <div class="page-content">
@@ -723,33 +696,7 @@ const shownModeLinks = computed(() =>
   padding-bottom: 0;
 }
 
-.layout-navlinks {
-  display: flex;
-  align-items: center;
-  gap: 0.375rem;
-  font-size: var(--fad-font-size-sm);
-}
-
-.layout-navlinks-separator {
-  color: var(--p-surface-400, #94a3b8);
-  opacity: 0.5;
-}
-
-.layout-navlink {
-  color: var(--p-primary-500, #3b82f6);
-  text-decoration: none;
-  transition: color var(--fad-transition-fast);
-}
-
-.layout-navlink:hover {
-  color: var(--p-primary-600, #2563eb);
-}
-
-.layout-navlink--active {
-  color: var(--p-surface-600, #475569);
-  font-weight: var(--fad-font-weight-medium);
-  pointer-events: none;
-}
+/* Navlinks styles moved to NavlinksGroup.vue (#1357) */
 
 /* Override PrimeVue Breadcrumb styles for flat look */
 .layout-nav-bar :deep(.p-breadcrumb) {

--- a/packages/qdadm/src/components/layout/NavlinksGroup.vue
+++ b/packages/qdadm/src/components/layout/NavlinksGroup.vue
@@ -1,0 +1,153 @@
+<script setup lang="ts">
+/**
+ * NavlinksGroup - the right-side navigation group of a breadcrumb bar (#1357)
+ *
+ * Single rendering of the contract previously copy-pasted between AppLayout's
+ * inline breadcrumb and DefaultBreadcrumb: View↔Edit mode links LEAD the
+ * group (#1332/#1341/#1353, order #j7udkh), sibling navlinks follow, pipe
+ * separators between every pair, plain text (no icons).
+ *
+ * Owns the two behaviors both call sites need:
+ * - the `qdadmFeatures.breadcrumbModeToggle` opt-in gate on mode links
+ * - dedup (#1357): a navlink whose target route is already covered by a
+ *   shown mode link is dropped — e.g. the auto "Details" link resolves to
+ *   the parent's edit route and would render twice ("Details" + "Edit").
+ *   With the feature off, no mode links are shown and every navlink stays
+ *   (back-compat).
+ *
+ * `variant` keeps the historical CSS hooks of each call site so consumer
+ * overrides keep working: 'layout' = AppLayout classes, 'breadcrumb' =
+ * DefaultBreadcrumb classes.
+ */
+import { computed, inject } from 'vue'
+import { RouterLink } from 'vue-router'
+import type { NavLinkItem, BreadcrumbModeToggle } from '../../composables/useNavContext'
+
+interface FeaturesConfig {
+  breadcrumbModeToggle?: boolean
+  [key: string]: unknown
+}
+
+const props = withDefaults(
+  defineProps<{
+    navlinks?: NavLinkItem[]
+    modeLinks?: BreadcrumbModeToggle[]
+    variant?: 'layout' | 'breadcrumb'
+  }>(),
+  {
+    navlinks: () => [],
+    modeLinks: () => [],
+    variant: 'breadcrumb',
+  }
+)
+
+const features = inject<FeaturesConfig>('qdadmFeatures', {})
+
+// Opt-in (#1332): mode links render only when the feature flag is on
+const shownModeLinks = computed<BreadcrumbModeToggle[]>(() =>
+  features.breadcrumbModeToggle === true ? props.modeLinks : []
+)
+
+// Dedup (#1357): drop navlinks targeting a route a mode link already covers
+const shownNavlinks = computed<NavLinkItem[]>(() => {
+  if (shownModeLinks.value.length === 0) return props.navlinks
+  const covered = new Set(shownModeLinks.value.map((m) => m.to.name))
+  return props.navlinks.filter((link) => !link.to?.name || !covered.has(link.to.name))
+})
+
+const cls = computed(() =>
+  props.variant === 'layout'
+    ? {
+        container: 'layout-navlinks',
+        separator: 'layout-navlinks-separator',
+        link: 'layout-navlink',
+        active: 'layout-navlink--active',
+      }
+    : {
+        container: 'breadcrumb-navlinks',
+        separator: 'navlinks-separator',
+        link: 'navlink',
+        active: 'navlink--active',
+      }
+)
+</script>
+
+<template>
+  <!-- Plain navigation; the form page's own route-leave guard covers
+       unsaved changes on edit→show -->
+  <div v-if="shownNavlinks.length > 0 || shownModeLinks.length > 0" :class="cls.container">
+    <!-- mode links lead the group (#j7udkh), sibling tabs follow -->
+    <template v-for="(mode, index) in shownModeLinks" :key="`mode-${mode.target}`">
+      <span v-if="index > 0" :class="cls.separator">|</span>
+      <RouterLink :to="mode.to" class="breadcrumb-mode-toggle" :class="cls.link">
+        {{ mode.label }}
+      </RouterLink>
+    </template>
+    <template v-for="(link, index) in shownNavlinks" :key="link.to?.name || index">
+      <span v-if="shownModeLinks.length > 0 || index > 0" :class="cls.separator">|</span>
+      <RouterLink :to="link.to" :class="[cls.link, { [cls.active]: link.active }]">
+        {{ link.label }}
+      </RouterLink>
+    </template>
+  </div>
+</template>
+
+<style scoped>
+/* Historical styles of each call site, keyed by variant container so the
+   look of both bars is preserved exactly (AppLayout was compact). */
+.layout-navlinks {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  font-size: var(--fad-font-size-sm);
+}
+
+.layout-navlinks-separator {
+  color: var(--p-surface-400, #94a3b8);
+  opacity: 0.5;
+}
+
+.layout-navlink {
+  color: var(--p-primary-500, #3b82f6);
+  text-decoration: none;
+  transition: color var(--fad-transition-fast);
+}
+
+.layout-navlink:hover {
+  color: var(--p-primary-600, #2563eb);
+}
+
+.layout-navlink--active {
+  color: var(--p-surface-600, #475569);
+  font-weight: var(--fad-font-weight-medium);
+  pointer-events: none;
+}
+
+.breadcrumb-navlinks {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.875rem;
+}
+
+.navlinks-separator {
+  color: var(--p-surface-400, #94a3b8);
+}
+
+.navlink {
+  color: var(--p-primary-500, #3b82f6);
+  text-decoration: none;
+  transition: color 0.15s;
+}
+
+.navlink:hover {
+  color: var(--p-primary-700, #1d4ed8);
+  text-decoration: underline;
+}
+
+.navlink--active {
+  color: var(--p-surface-700, #334155);
+  font-weight: 500;
+  pointer-events: none;
+}
+</style>

--- a/packages/qdadm/src/components/layout/defaults/DefaultBreadcrumb.vue
+++ b/packages/qdadm/src/components/layout/defaults/DefaultBreadcrumb.vue
@@ -12,11 +12,10 @@ import { computed, inject, ref, type Ref } from 'vue'
 import { RouterLink, useRoute } from 'vue-router'
 import { useNavContext, type BreadcrumbItem, type NavLinkItem } from '../../../composables/useNavContext'
 import Breadcrumb from 'primevue/breadcrumb'
+import NavlinksGroup from '../NavlinksGroup.vue'
 
 interface FeaturesConfig {
   breadcrumb?: boolean
-  /** Opt-in (#1332): render a View↔Edit toggle next to the terminal crumb */
-  breadcrumbModeToggle?: boolean
   [key: string]: unknown
 }
 
@@ -42,11 +41,6 @@ const showBreadcrumb = computed<boolean>(() => {
   return true
 })
 
-// View↔Edit mode links (#1332/#1353) — opt-in; single opposite-mode link on
-// item pages, the parent's View/Edit pair on child pages
-const shownModeLinks = computed(() =>
-  features.breadcrumbModeToggle === true ? modeLinks.value : []
-)
 </script>
 
 <template>
@@ -65,30 +59,8 @@ const shownModeLinks = computed(() =>
     </Breadcrumb>
 
     <!-- Navlinks (provided by PageNav for child routes) + View↔Edit mode
-         links (#1332/#1341/#1353) — plain navigation; the form page's own
-         route-leave guard covers unsaved changes on edit→show -->
-    <div v-if="navlinks.length > 0 || shownModeLinks.length > 0" class="breadcrumb-navlinks">
-      <!-- mode links lead the group (#j7udkh), sibling tabs follow -->
-      <template v-for="(mode, index) in shownModeLinks" :key="`mode-${mode.target}`">
-        <span v-if="index > 0" class="navlinks-separator">|</span>
-        <RouterLink
-          :to="mode.to"
-          class="navlink breadcrumb-mode-toggle"
-        >
-          {{ mode.label }}
-        </RouterLink>
-      </template>
-      <template v-for="(link, index) in navlinks" :key="link.to?.name || index">
-        <span v-if="shownModeLinks.length > 0 || index > 0" class="navlinks-separator">|</span>
-        <RouterLink
-          :to="link.to"
-          class="navlink"
-          :class="{ 'navlink--active': link.active }"
-        >
-          {{ link.label }}
-        </RouterLink>
-      </template>
-    </div>
+         links (#1332/#1341/#1353) — shared rendering + dedup (#1357) -->
+    <NavlinksGroup :navlinks="navlinks" :mode-links="modeLinks" variant="breadcrumb" />
   </div>
 </template>
 
@@ -105,33 +77,7 @@ const shownModeLinks = computed(() =>
   padding-bottom: 0;
 }
 
-.breadcrumb-navlinks {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  font-size: 0.875rem;
-}
-
-.navlinks-separator {
-  color: var(--p-surface-400, #94a3b8);
-}
-
-.navlink {
-  color: var(--p-primary-500, #3b82f6);
-  text-decoration: none;
-  transition: color 0.15s;
-}
-
-.navlink:hover {
-  color: var(--p-primary-700, #1d4ed8);
-  text-decoration: underline;
-}
-
-.navlink--active {
-  color: var(--p-surface-700, #334155);
-  font-weight: 500;
-  pointer-events: none;
-}
+/* Navlinks styles moved to NavlinksGroup.vue (#1357) */
 
 /* Override PrimeVue Breadcrumb styles for flat look */
 .default-breadcrumb :deep(.p-breadcrumb) {

--- a/packages/qdadm/src/composables/useNavContext.ts
+++ b/packages/qdadm/src/composables/useNavContext.ts
@@ -377,6 +377,8 @@ export function useNavContext(_options: UseNavContextOptions = {}): UseNavContex
   })
 
   const navlinks = computed(() => {
+    void i18nLocale.value // "Details" label re-resolves on locale change
+
     if (!parentConfig.value) return []
 
     const { entity: parentEntity, param, itemRoute } = parentConfig.value
@@ -391,7 +393,7 @@ export function useNavContext(_options: UseNavContextOptions = {}): UseNavContex
     // Details link - use manager's idField for param name
     const links: NavLinkItem[] = [
       {
-        label: 'Details',
+        label: breadcrumbLabel('details', 'Details'),
         to: {
           name: parentRouteName!,
           params: { [parentManager.idField!]: parentId.value as string },
@@ -448,10 +450,17 @@ export function useNavContext(_options: UseNavContextOptions = {}): UseNavContex
   // MODE TOGGLE / MODE LINKS (#1332, #1353)
   // ============================================================================
 
-  function toggleLabel(target: 'show' | 'edit'): string {
-    const trace = kernelI18n?.resolve(target === 'edit' ? 'breadcrumb.edit' : 'breadcrumb.view')
+  /** Resolve a `breadcrumb.*` label from the i18n catalog, with fallback. */
+  function breadcrumbLabel(key: string, fallback: string): string {
+    const trace = kernelI18n?.resolve(`breadcrumb.${key}`)
     if (trace?.hit) return trace.result
-    return target === 'edit' ? 'Edit' : 'View'
+    return fallback
+  }
+
+  function toggleLabel(target: 'show' | 'edit'): string {
+    return target === 'edit'
+      ? breadcrumbLabel('edit', 'Edit')
+      : breadcrumbLabel('view', 'View')
   }
 
   /** Build one mode link if its route exists and (for edit) permission allows. */

--- a/packages/qdadm/tests/components/NavlinksGroup.test.js
+++ b/packages/qdadm/tests/components/NavlinksGroup.test.js
@@ -1,0 +1,94 @@
+/**
+ * Unit tests for NavlinksGroup (#1357)
+ *
+ * The shared right-side breadcrumb group: mode links lead, sibling navlinks
+ * follow, and a navlink whose target route is already covered by a shown
+ * mode link is deduped (the auto "Details" link resolves to the parent's
+ * edit route and rendered twice as "Details" + "Edit").
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import NavlinksGroup from '../../src/components/layout/NavlinksGroup.vue'
+
+vi.mock('vue-router', () => ({
+  RouterLink: {
+    name: 'RouterLink',
+    props: ['to'],
+    template: '<a class="router-link"><slot /></a>',
+  },
+}))
+
+const MODE_LINKS = [
+  { target: 'show', to: { name: 'genres-show', params: { id: 'fiction' } }, label: 'View' },
+  { target: 'edit', to: { name: 'genres-edit', params: { id: 'fiction' } }, label: 'Edit' },
+]
+
+const NAVLINKS = [
+  // the auto "Details" link — same route as the Edit mode link
+  { label: 'Details', to: { name: 'genres-edit', params: { id: 'fiction' } }, active: false },
+  { label: 'Books', to: { name: 'genre-books', params: { id: 'fiction' } }, active: true },
+]
+
+function mountGroup(props, { features } = {}) {
+  return mount(NavlinksGroup, {
+    props,
+    global: {
+      provide: features === undefined ? {} : { qdadmFeatures: features },
+    },
+  })
+}
+
+describe('NavlinksGroup dedup (#1357)', () => {
+  it('drops a navlink whose route a shown mode link already covers', () => {
+    const wrapper = mountGroup(
+      { modeLinks: MODE_LINKS, navlinks: NAVLINKS, variant: 'breadcrumb' },
+      { features: { breadcrumbModeToggle: true } }
+    )
+
+    const labels = wrapper.findAll('a').map((a) => a.text())
+    expect(labels).toEqual(['View', 'Edit', 'Books'])
+    expect(labels).not.toContain('Details')
+  })
+
+  it('keeps every navlink when the feature is off (no mode links shown)', () => {
+    const wrapper = mountGroup({ modeLinks: MODE_LINKS, navlinks: NAVLINKS })
+
+    expect(wrapper.findAll('a').map((a) => a.text())).toEqual(['Details', 'Books'])
+    expect(wrapper.find('.breadcrumb-mode-toggle').exists()).toBe(false)
+  })
+
+  it('keeps navlinks that target uncovered routes', () => {
+    const wrapper = mountGroup(
+      {
+        modeLinks: [MODE_LINKS[1]], // Edit only
+        navlinks: [{ label: 'Details', to: { name: 'genres-show', params: { id: 'fiction' } }, active: false }],
+      },
+      { features: { breadcrumbModeToggle: true } }
+    )
+
+    expect(wrapper.findAll('a').map((a) => a.text())).toEqual(['Edit', 'Details'])
+  })
+})
+
+describe('NavlinksGroup rendering contract', () => {
+  it('mode links lead, separators between every pair, variant classes applied', () => {
+    const wrapper = mountGroup(
+      { modeLinks: MODE_LINKS, navlinks: [NAVLINKS[1]], variant: 'layout' },
+      { features: { breadcrumbModeToggle: true } }
+    )
+
+    expect(wrapper.find('.layout-navlinks').exists()).toBe(true)
+    const links = wrapper.findAll('a')
+    expect(links.map((a) => a.text())).toEqual(['View', 'Edit', 'Books'])
+    expect(links[0].classes()).toContain('layout-navlink')
+    expect(links[0].classes()).toContain('breadcrumb-mode-toggle')
+    expect(links[2].classes()).toContain('layout-navlink--active')
+    expect(wrapper.findAll('.layout-navlinks-separator')).toHaveLength(2)
+  })
+
+  it('renders nothing when both lists are empty after gating', () => {
+    const wrapper = mountGroup({ modeLinks: MODE_LINKS, navlinks: [] })
+
+    expect(wrapper.find('div').exists()).toBe(false)
+  })
+})


### PR DESCRIPTION
Executes the accepted plan on aiball #1357.

## What

1. **Dedup fix**: on child pages with `breadcrumbModeToggle` on, the auto **Details** navlink resolves to the parent's edit route (`getDefaultItemRoute` prefers `-edit`) — the same destination as the **Edit** mode link, so the link was injected twice since #1353. A navlink whose target route is covered by a shown mode link is now dropped. Flag off → no mode links → every navlink stays (back-compat).
2. **DRY**: new `NavlinksGroup` component (exported) — single rendering of the mode-links + navlinks contract previously copy-pasted between AppLayout's inline breadcrumb and DefaultBreadcrumb. Owns the feature gate, ordering (mode links lead, #j7udkh), separators, and per-variant historical CSS hooks (`layout-*` / `navlink*`).
3. **i18n**: Details label via `breadcrumb.details` (fallback `Details`), locale-reactive, same pattern as `breadcrumb.view`/`breadcrumb.edit`.
4. **Docs**: `docs/navigation.md` gains the inventory of auto-injected nav affordances (Details / sibling tabs / mode links / list-page create action) with automatic-vs-opt-in status and label resolution rules.

Demo effect on `/genres/fiction/books`: `Edit | Details | Books` (Details ≡ Edit) → `Edit | Books`.

## Tests

- New `NavlinksGroup.test.js` (5): dedup on covered route, back-compat with flag off, uncovered navlink kept, ordering + variant classes, empty render.
- Existing AppLayout/DefaultBreadcrumb suites pass **unchanged** (markup contract preserved through the shared component).
- Full suite: 2066 green. `type-check` clean; changed files lint-clean.